### PR TITLE
Fix(Tests): Correct Moq setup for BucketExistsAsync

### DIFF
--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/MinIOImageUploadServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/MinIOImageUploadServiceTests.cs
@@ -60,7 +60,7 @@ namespace AzurePhotoFlow.Api.Tests.UnitTests
 
             // Default setup for BucketExistsAsync
             _mockMinioClient.Setup(c => c.BucketExistsAsync(
-                It.Is<BucketExistsArgs>(args => args.BucketName == BucketName), 
+                It.IsAny<BucketExistsArgs>(), 
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
             


### PR DESCRIPTION
Changed the Moq setup for `IMinioClient.BucketExistsAsync` in `MinIOImageUploadServiceTests.cs` to use `It.IsAny<BucketExistsArgs>()` instead of attempting to match on the `BucketName` property of `BucketExistsArgs`.

The `BucketExistsArgs` class uses a fluent builder pattern and does not expose a public `BucketName` property, which caused a compiler error in the previous predicate `args => args.BucketName == BucketName`. This change resolves the compiler error in the unit tests.