### PR TITLE
Fix: Handle space encoding in MinIO project names

### DIFF
--- a/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Concurrent;
 using Minio.DataModel;
 using System.Collections.Generic; // Added for HashSet
+using System.Net;
 
 namespace AzurePhotoFlow.Services;
 
@@ -239,7 +240,8 @@ public class MinIOImageUploadService : IImageUploadService
             if (parts.Length == 2)
             {
                 string currentDateStamp = parts[0];
-                string currentProjectName = parts[1];
+                string currentProjectNameFromKey = parts[1];
+                string decodedProjectNameFromKey = System.Net.WebUtility.UrlDecode(currentProjectNameFromKey);
                 string currentYear = currentDateStamp[..4];
 
                 // ---------------- filters ----------------
@@ -247,7 +249,7 @@ public class MinIOImageUploadService : IImageUploadService
                     continue;
 
                 if (!string.IsNullOrEmpty(projectName) &&
-                    !currentProjectName.Equals(projectName,
+                    !decodedProjectNameFromKey.Equals(projectName,
                                               StringComparison.OrdinalIgnoreCase))
                     continue;
 
@@ -272,14 +274,14 @@ public class MinIOImageUploadService : IImageUploadService
 
                 var projectInfo = new ProjectInfo
                 {
-                    Name = currentProjectName,
+                    Name = decodedProjectNameFromKey,
                     Datestamp = finalDate,
                     Directories = await GetDirectoryDetailsAsync(dirPrefix, ct)
                 };
 
                 projects.Add(projectInfo);
                 _log.LogInformation("Added {Project} ({Stamp})",
-                                    currentProjectName, currentDateStamp);
+                                    decodedProjectNameFromKey, currentDateStamp);
             }
             else
             {


### PR DESCRIPTION
When project names containing spaces were used, MinIO (or its SDK) appeared to store these spaces as '+' characters in the object keys. The `GetProjectsAsync` method in `MinIOImageUploadService` would then fail to match these encoded names against the original project names (with spaces) provided in filters, because it was comparing, for example, "My+Project" (from MinIO) with "My Project" (filter).

This commit addresses the issue by:
1. Modifying `MinIOImageUploadService.ProcessHierarchyAsync`:
   - Project name segments extracted from MinIO object keys are now explicitly URL-decoded using `System.Net.WebUtility.UrlDecode()`.
   - This decoded name is used for comparisons against filters and for populating the `ProjectInfo.Name` field, ensuring the application consistently works with your user-friendly name (with spaces).

2. Adding Unit Tests to `MinIOImageUploadServiceTests.cs`:
   - `GetProjectsAsync_ProjectNameWithSpaces_FiltersAndDecodesCorrectly`: Tests that filtering by a project name with spaces correctly matches and decodes a project name stored with '+' by MinIO.
   - `GetProjectsAsync_NoFilter_DecodesProjectNamesCorrectly`: Tests that when no project name filter is applied, any project names listed from MinIO with encoded spaces are correctly decoded in the `ProjectInfo` results.

The `MinIODirectoryHelper.Sanitize` method was reviewed and confirmed to not conflict with this fix, as it handles path normalization rather than URL encoding.