### PR TITLE
Add embedding service and qdrant

### DIFF
--- a/backend/AzurePhotoFlow.EmbeddingService/Dockerfile
+++ b/backend/AzurePhotoFlow.EmbeddingService/Dockerfile
@@ -1,0 +1,60 @@
+#############################################
+# 1) Build Stage
+#############################################
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# Create and switch to a new working directory for the build
+WORKDIR /src
+
+# Copy the POCO project
+COPY backend/AzurePhotoFlow.POCO ./AzurePhotoFlow.POCO
+
+# Copy the EmbeddingService project
+COPY backend/AzurePhotoFlow.EmbeddingService ./AzurePhotoFlow.EmbeddingService
+
+# Switch into the EmbeddingService folder
+WORKDIR /src/AzurePhotoFlow.EmbeddingService
+
+# Restore dependencies
+RUN dotnet restore AzurePhotoFlow.EmbeddingService.csproj
+
+# Copy the rest of the source code
+COPY . .
+
+# Build-time arguments
+ARG QDRANT_URL
+ARG QDRANT_COLLECTION
+ARG CLIP_MODEL_PATH
+ARG MINIO_ENDPOINT
+ARG MINIO_ACCESS_KEY
+ARG MINIO_SECRET_KEY
+ENV QDRANT_URL=$QDRANT_URL
+ENV QDRANT_COLLECTION=$QDRANT_COLLECTION
+ENV CLIP_MODEL_PATH=$CLIP_MODEL_PATH
+ENV MINIO_ENDPOINT=$MINIO_ENDPOINT
+ENV MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY
+ENV MINIO_SECRET_KEY=$MINIO_SECRET_KEY
+
+# Publish the application
+RUN dotnet publish backend/AzurePhotoFlow.EmbeddingService/AzurePhotoFlow.EmbeddingService.csproj \
+    -c Release \
+    -o /app/out
+
+#############################################
+# 2) Runtime Stage
+#############################################
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=build /app/out ./
+
+ENV ASPNETCORE_URLS=http://+:80
+
+EXPOSE 80
+
+ENTRYPOINT ["dotnet", "AzurePhotoFlow.EmbeddingService.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,39 @@ services:
       - MINIO_ENDPOINT=${MINIO_ENDPOINT}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - EMBEDDING_SERVICE_URL=http://embedding:80
+    networks:
+      - app-network
+
+  embedding:
+    build:
+      context: .
+      dockerfile: backend/AzurePhotoFlow.EmbeddingService/Dockerfile
+      args:
+        QDRANT_URL: ${QDRANT_URL}
+        QDRANT_COLLECTION: ${QDRANT_COLLECTION}
+        CLIP_MODEL_PATH: ${CLIP_MODEL_PATH}
+        MINIO_ENDPOINT: ${MINIO_ENDPOINT}
+        MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+        MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+    environment:
+      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_COLLECTION=${QDRANT_COLLECTION}
+      - CLIP_MODEL_PATH=${CLIP_MODEL_PATH}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - ASPNETCORE_URLS=http://+:80
+    container_name: embedding
+    networks:
+      - app-network
+    expose:
+      - "80"
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- add Dockerfile for EmbeddingService
- wire up embedding service and qdrant in docker-compose
- expose EMBEDDING_SERVICE_URL to backend

## Testing
- `dotnet test tests/backend/backend.tests.sln --verbosity normal` *(fails: ListObjectsArgs missing)*
- `npm test` in `tests/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6841724c2f7c8329880d4242e5baa734