### PR TITLE
Fix missing references for EmbeddingGeneratorService

### DIFF
--- a/backend/AzurePhotoFlow.EmbeddingService/AzurePhotoFlow.EmbeddingService.csproj
+++ b/backend/AzurePhotoFlow.EmbeddingService/AzurePhotoFlow.EmbeddingService.csproj
@@ -13,5 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\AzurePhotoFlow.Api\AzurePhotoFlow.Api.csproj" />
     <ProjectReference Include="..\AzurePhotoFlow.POCO\AzurePhotoFlow.POCO.csproj" />
+    <ProjectReference Include="..\AzurePhotoFlow.Shared\AzurePhotoFlow.Shared.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix namespace conflicts and alias types in `EmbeddingGeneratorService`
- add project reference to `AzurePhotoFlow.Shared`

## Testing
- `dotnet build backend/AzurePhotoFlow.EmbeddingService/AzurePhotoFlow.EmbeddingService.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6841e34a327483298bb073fd7054316a