### PR TITLE
Move generate endpoint into controller

### DIFF
--- a/backend/AzurePhotoFlow.EmbeddingService/Controllers/EmbeddingGeneratorController.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Controllers/EmbeddingGeneratorController.cs
@@ -1,0 +1,25 @@
+using Api.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzurePhotoFlow.Services;
+
+[ApiController]
+[Route("")]
+public class EmbeddingGeneratorController : ControllerBase
+{
+    private readonly IEmbeddingGeneratorService _generatorService;
+
+    public EmbeddingGeneratorController(IEmbeddingGeneratorService generatorService)
+    {
+        _generatorService = generatorService;
+    }
+
+    [HttpPost("generate")]
+    public async Task<IActionResult> Generate([FromBody] EmbeddingRequest request)
+    {
+        await _generatorService.GenerateAsync(request.ProjectName, request.DirectoryName, request.Timestamp);
+        return Ok();
+    }
+}
+
+public record EmbeddingRequest(string ProjectName, string DirectoryName, DateTime Timestamp);

--- a/backend/AzurePhotoFlow.EmbeddingService/Program.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Program.cs
@@ -1,12 +1,12 @@
 using AzurePhotoFlow.Services;
 using Api.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using Minio;
 using Qdrant.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddLogging();
+builder.Services.AddControllers();
 
 builder.Services.AddSingleton<IMinioClient>(sp =>
 {
@@ -26,12 +26,6 @@ builder.Services.AddSingleton<IEmbeddingGeneratorService, EmbeddingGeneratorServ
 
 var app = builder.Build();
 
-app.MapPost("/generate", async ([FromBody]EmbeddingRequest req, IEmbeddingGeneratorService generator) =>
-{
-    await generator.GenerateAsync(req.ProjectName, req.DirectoryName, req.Timestamp);
-    return Results.Ok();
-});
+app.MapControllers();
 
 app.Run();
-
-public record EmbeddingRequest(string ProjectName, string DirectoryName, DateTime Timestamp);


### PR DESCRIPTION
## Summary
- add EmbeddingGeneratorController with POST /generate
- register controllers in EmbeddingGeneratorService Program

## Testing
- `dotnet test tests/backend/backend.tests.sln`
- `dotnet build backend/AzurePhotoFlow.EmbeddingService/AzurePhotoFlow.EmbeddingService.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6841e5e5cacc8329bba9537523d11ab0