### PR TITLE
Compute embeddings during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AzurePhotoFlow is a cloud-native application designed to help users manage, anal
 - **Optical Character Recognition (OCR):** Extract text from images.
 - **Semantic Search (Natural Language Search):** Search photos using natural language queries.
 - **Metadata-based Search:** Search photos based on metadata like filename, date, and tags.
-- **Vector Embeddings:** After uploads, a notification is sent to an embedding service which writes image vectors to Qdrant for similarity search.
+- **Vector Embeddings:** Embeddings are computed during upload and stored directly in Qdrant for similarity search.
 
 ## Architecture
 AzurePhotoFlow utilizes a modern cloud architecture with the following key components:

--- a/backend/AzurePhotoFlow.Api/AzurePhotoFlow.Api.csproj
+++ b/backend/AzurePhotoFlow.Api/AzurePhotoFlow.Api.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Minio" Version="6.0.4" />
+    <PackageReference Include="Qdrant.Client" Version="1.14.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />

--- a/backend/AzurePhotoFlow.Api/Interfaces/IImageEmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Interfaces/IImageEmbeddingService.cs
@@ -1,0 +1,6 @@
+namespace Api.Interfaces;
+
+public interface IImageEmbeddingService
+{
+    Task StoreEmbeddingAsync(string objectKey, byte[] imageBytes);
+}

--- a/backend/AzurePhotoFlow.Api/Services/ImageEmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/ImageEmbeddingService.cs
@@ -1,0 +1,68 @@
+using Api.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLaborsImage = SixLabors.ImageSharp.Image;
+using QdrantValue = Qdrant.Client.Grpc.Value;
+
+namespace AzurePhotoFlow.Services;
+
+public class ImageEmbeddingService : IImageEmbeddingService
+{
+    private readonly QdrantClient _qdrantClient;
+    private readonly InferenceSession _session;
+    private readonly ILogger<ImageEmbeddingService> _logger;
+    private readonly string _collection;
+
+    public ImageEmbeddingService(QdrantClient qdrantClient, InferenceSession session, ILogger<ImageEmbeddingService> logger)
+    {
+        _qdrantClient = qdrantClient;
+        _session = session;
+        _logger = logger;
+        _collection = Environment.GetEnvironmentVariable("QDRANT_COLLECTION") ?? "images";
+    }
+
+    public async Task StoreEmbeddingAsync(string objectKey, byte[] imageBytes)
+    {
+        try
+        {
+            float[] vector = GenerateEmbedding(imageBytes);
+            var point = new PointStruct
+            {
+                Id = new PointId { Uuid = objectKey },
+                Vectors = vector
+            };
+            point.Payload.Add("path", new QdrantValue { StringValue = objectKey });
+            await _qdrantClient.UpsertAsync(_collection, new[] { point });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to store embedding for {ObjectKey}", objectKey);
+        }
+    }
+
+    private float[] GenerateEmbedding(byte[] imageBytes)
+    {
+        using var image = SixLaborsImage.Load<Rgb24>(imageBytes);
+        image.Mutate(x => x.Resize(224, 224));
+        var tensor = new DenseTensor<float>(new[] { 1, 3, 224, 224 });
+        for (int y = 0; y < 224; y++)
+        {
+            for (int x = 0; x < 224; x++)
+            {
+                var p = image[x, y];
+                tensor[0, 0, y, x] = p.R / 255f;
+                tensor[0, 1, y, x] = p.G / 255f;
+                tensor[0, 2, y, x] = p.B / 255f;
+            }
+        }
+        var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input", tensor) };
+        using var results = _session.Run(inputs);
+        return results.First().AsEnumerable<float>().ToArray();
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/MinIOImageUploadServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/MinIOImageUploadServiceTests.cs
@@ -15,7 +15,7 @@ namespace unitTests
         private readonly Mock<IMinioClient> _mockMinioClient;
         private readonly Mock<ILogger<MinIOImageUploadService>> _mockLogger;
         private readonly Mock<IMetadataExtractorService> _mockMetadataExtractorService;
-        private readonly Mock<IEmbeddingNotificationService> _mockEmbeddingNotificationService;
+        private readonly Mock<IImageEmbeddingService> _mockImageEmbeddingService;
         private readonly MinIOImageUploadService _service;
 
         private const string BucketName = "photostore";
@@ -29,13 +29,13 @@ namespace unitTests
             _mockMinioClient = new Mock<IMinioClient>();
             _mockLogger = new Mock<ILogger<MinIOImageUploadService>>();
             _mockMetadataExtractorService = new Mock<IMetadataExtractorService>();
-            _mockEmbeddingNotificationService = new Mock<IEmbeddingNotificationService>();
+            _mockImageEmbeddingService = new Mock<IImageEmbeddingService>();
 
             _service = new MinIOImageUploadService(
                 _mockMinioClient.Object,
                 _mockLogger.Object,
                 _mockMetadataExtractorService.Object,
-                _mockEmbeddingNotificationService.Object
+                _mockImageEmbeddingService.Object
             );
 
             // Default setup for BucketExistsAsync


### PR DESCRIPTION
## Summary
- compute embeddings before uploading each file
- store embeddings directly in Qdrant via new `ImageEmbeddingService`
- wire up `ImageEmbeddingService` in DI
- update tests and README

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841eea3931c832981e5bcc4b91f45f1