### PR TITLE
Add unit tests for EmbeddingService

### DIFF
--- a/backend/AzurePhotoFlow.EmbeddingService/Interfaces/IImageEmbeddingModel.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Interfaces/IImageEmbeddingModel.cs
@@ -1,0 +1,6 @@
+namespace AzurePhotoFlow.Services;
+
+public interface IImageEmbeddingModel
+{
+    float[] GenerateEmbedding(byte[] imageBytes);
+}

--- a/backend/AzurePhotoFlow.EmbeddingService/Interfaces/IQdrantClientWrapper.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Interfaces/IQdrantClientWrapper.cs
@@ -1,0 +1,8 @@
+using Qdrant.Client.Grpc;
+
+namespace AzurePhotoFlow.Services;
+
+public interface IQdrantClientWrapper
+{
+    Task UpsertAsync(string collection, IEnumerable<PointStruct> points);
+}

--- a/backend/AzurePhotoFlow.EmbeddingService/Program.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Program.cs
@@ -1,6 +1,7 @@
 using AzurePhotoFlow.Services;
 using Api.Interfaces;
 using Qdrant.Client;
+using Microsoft.ML.OnnxRuntime;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +14,13 @@ builder.Services.AddSingleton(_ =>
     var url = Environment.GetEnvironmentVariable("QDRANT_URL") ?? "http://localhost:6333";
     return new QdrantClient(url);
 });
-
+builder.Services.AddSingleton<IQdrantClientWrapper, QdrantClientWrapper>();
+builder.Services.AddSingleton<IImageEmbeddingModel>(_ =>
+{
+    string modelPath = Environment.GetEnvironmentVariable("CLIP_MODEL_PATH") ?? "model.onnx";
+    var session = new InferenceSession(modelPath);
+    return new OnnxImageEmbeddingModel(session);
+});
 builder.Services.AddSingleton<IEmbeddingService, EmbeddingService>();
 
 var app = builder.Build();

--- a/backend/AzurePhotoFlow.EmbeddingService/Services/EmbeddingService.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Services/EmbeddingService.cs
@@ -1,43 +1,34 @@
 using Api.Interfaces;
 using Microsoft.Extensions.Logging;
-using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 using AzurePhotoFlow.Services;
 using Google.Protobuf.Collections;
 using QdrantValue = Qdrant.Client.Grpc.Value;
-using Microsoft.ML.OnnxRuntime;
-using Microsoft.ML.OnnxRuntime.Tensors;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
-using SixLaborsImage = SixLabors.ImageSharp.Image;
 
 namespace AzurePhotoFlow.Services;
 
 public class EmbeddingService : IEmbeddingService
 {
-    private readonly QdrantClient _qdrantClient;
+    private readonly IQdrantClientWrapper _qdrantClient;
     private readonly ILogger<EmbeddingService> _logger;
-    private readonly InferenceSession _session;
+    private readonly IImageEmbeddingModel _embeddingModel;
     private readonly string _collection;
 
-    public EmbeddingService(QdrantClient qdrantClient, ILogger<EmbeddingService> logger)
+    public EmbeddingService(IQdrantClientWrapper qdrantClient, ILogger<EmbeddingService> logger, IImageEmbeddingModel embeddingModel)
     {
         _qdrantClient = qdrantClient;
         _logger = logger;
+        _embeddingModel = embeddingModel;
         _collection = Environment.GetEnvironmentVariable("QDRANT_COLLECTION") ?? "images";
-        string modelPath = Environment.GetEnvironmentVariable("CLIP_MODEL_PATH") ?? "model.onnx";
-        _session = new InferenceSession(modelPath);
     }
 
     public async Task GenerateAsync(IEnumerable<ImageEmbeddingInput> images)
     {
         foreach (var image in images)
         {
-            float[] vector = GenerateEmbedding(image.ImageBytes);
+            float[] vector = _embeddingModel.GenerateEmbedding(image.ImageBytes);
 
             var point = new PointStruct
             {
@@ -47,25 +38,5 @@ public class EmbeddingService : IEmbeddingService
             point.Payload.Add("path", new QdrantValue { StringValue = image.ObjectKey });
             await _qdrantClient.UpsertAsync(_collection, new[] { point });
         }
-    }
-
-    private float[] GenerateEmbedding(byte[] imageBytes)
-    {
-        using var image = SixLaborsImage.Load<Rgb24>(imageBytes);
-        image.Mutate(x => x.Resize(224, 224));
-        var tensor = new DenseTensor<float>(new[] { 1, 3, 224, 224 });
-        for (int y = 0; y < 224; y++)
-        {
-            for (int x = 0; x < 224; x++)
-            {
-                var p = image[x, y];
-                tensor[0, 0, y, x] = p.R / 255f;
-                tensor[0, 1, y, x] = p.G / 255f;
-                tensor[0, 2, y, x] = p.B / 255f;
-            }
-        }
-        var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input", tensor) };
-        using var results = _session.Run(inputs);
-        return results.First().AsEnumerable<float>().ToArray();
     }
 }

--- a/backend/AzurePhotoFlow.EmbeddingService/Services/OnnxImageEmbeddingModel.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Services/OnnxImageEmbeddingModel.cs
@@ -1,0 +1,38 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLaborsImage = SixLabors.ImageSharp.Image;
+
+namespace AzurePhotoFlow.Services;
+
+public class OnnxImageEmbeddingModel : IImageEmbeddingModel
+{
+    private readonly InferenceSession _session;
+
+    public OnnxImageEmbeddingModel(InferenceSession session)
+    {
+        _session = session;
+    }
+
+    public float[] GenerateEmbedding(byte[] imageBytes)
+    {
+        using var image = SixLaborsImage.Load<Rgb24>(imageBytes);
+        image.Mutate(x => x.Resize(224, 224));
+        var tensor = new DenseTensor<float>(new[] { 1, 3, 224, 224 });
+        for (int y = 0; y < 224; y++)
+        {
+            for (int x = 0; x < 224; x++)
+            {
+                var p = image[x, y];
+                tensor[0, 0, y, x] = p.R / 255f;
+                tensor[0, 1, y, x] = p.G / 255f;
+                tensor[0, 2, y, x] = p.B / 255f;
+            }
+        }
+        var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input", tensor) };
+        using var results = _session.Run(inputs);
+        return results.First().AsEnumerable<float>().ToArray();
+    }
+}

--- a/backend/AzurePhotoFlow.EmbeddingService/Services/QdrantClientWrapper.cs
+++ b/backend/AzurePhotoFlow.EmbeddingService/Services/QdrantClientWrapper.cs
@@ -1,0 +1,19 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+namespace AzurePhotoFlow.Services;
+
+public class QdrantClientWrapper : IQdrantClientWrapper
+{
+    private readonly QdrantClient _client;
+
+    public QdrantClientWrapper(QdrantClient client)
+    {
+        _client = client;
+    }
+
+    public async Task UpsertAsync(string collection, IEnumerable<PointStruct> points)
+    {
+        await _client.UpsertAsync(collection, points.ToList());
+    }
+}

--- a/tests/backend/AzurePhotoFlow.EmbeddingService.Tests/AzurePhotoFlow.EmbeddingService.Tests.csproj
+++ b/tests/backend/AzurePhotoFlow.EmbeddingService.Tests/AzurePhotoFlow.EmbeddingService.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\backend\AzurePhotoFlow.EmbeddingService\AzurePhotoFlow.EmbeddingService.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/backend/AzurePhotoFlow.EmbeddingService.Tests/EmbeddingServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.EmbeddingService.Tests/EmbeddingServiceTests.cs
@@ -1,0 +1,47 @@
+using AzurePhotoFlow.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Qdrant.Client.Grpc;
+
+namespace unitTests;
+
+[TestFixture]
+public class EmbeddingServiceTests
+{
+    [Test]
+    public async Task GenerateAsync_UpsertsEachImageWithEmbedding()
+    {
+        var qdrantMock = new Mock<IQdrantClientWrapper>();
+        var loggerMock = new Mock<ILogger<EmbeddingService>>();
+        var modelMock = new Mock<IImageEmbeddingModel>();
+        var vector = new float[] { 0.1f, 0.2f };
+        modelMock.Setup(m => m.GenerateEmbedding(It.IsAny<byte[]>())).Returns(vector);
+
+        var service = new EmbeddingService(qdrantMock.Object, loggerMock.Object, modelMock.Object);
+
+        var images = new[]
+        {
+            new ImageEmbeddingInput("obj1", new byte[]{1}),
+            new ImageEmbeddingInput("obj2", new byte[]{2})
+        };
+
+        await service.GenerateAsync(images);
+
+        qdrantMock.Verify(c => c.UpsertAsync(
+            It.Is<string>(s => s == "images"),
+            It.Is<IEnumerable<PointStruct>>(p =>
+                p.Single().Id.Uuid == "obj1" &&
+                p.Single().Vectors.Vector.Data.SequenceEqual(vector))
+        ), Times.Once);
+
+        qdrantMock.Verify(c => c.UpsertAsync(
+            It.Is<string>(s => s == "images"),
+            It.Is<IEnumerable<PointStruct>>(p =>
+                p.Single().Id.Uuid == "obj2" &&
+                p.Single().Vectors.Vector.Data.SequenceEqual(vector))
+        ), Times.Once);
+
+        modelMock.Verify(m => m.GenerateEmbedding(It.IsAny<byte[]>()), Times.Exactly(2));
+    }
+}

--- a/tests/backend/backend.tests.sln
+++ b/tests/backend/backend.tests.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePhotoFlow.Api.Tests", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePhotoFlow.Functions.Tests", "AzurePhotoFlow.Functions.Tests\AzurePhotoFlow.Functions.Tests.csproj", "{B802EE95-E212-41D5-8F60-95AE05C97A72}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePhotoFlow.EmbeddingService.Tests", "AzurePhotoFlow.EmbeddingService.Tests\AzurePhotoFlow.EmbeddingService.Tests.csproj", "{A2F4F3C5-3A87-4D4C-8CF2-2570C9E234E1}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePhotoFlow.Tests.Utilities", "AzurePhotoFlow.Tests.Utilities\AzurePhotoFlow.Tests.Utilities.csproj", "{35371686-88E0-4701-A0BA-860DE1DC5E41}"
 EndProject
 Global
@@ -26,9 +28,13 @@ Global
 		{B802EE95-E212-41D5-8F60-95AE05C97A72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B802EE95-E212-41D5-8F60-95AE05C97A72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B802EE95-E212-41D5-8F60-95AE05C97A72}.Release|Any CPU.Build.0 = Release|Any CPU
-		{35371686-88E0-4701-A0BA-860DE1DC5E41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{35371686-88E0-4701-A0BA-860DE1DC5E41}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{35371686-88E0-4701-A0BA-860DE1DC5E41}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{35371686-88E0-4701-A0BA-860DE1DC5E41}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {35371686-88E0-4701-A0BA-860DE1DC5E41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {35371686-88E0-4701-A0BA-860DE1DC5E41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {35371686-88E0-4701-A0BA-860DE1DC5E41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {35371686-88E0-4701-A0BA-860DE1DC5E41}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A2F4F3C5-3A87-4D4C-8CF2-2570C9E234E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A2F4F3C5-3A87-4D4C-8CF2-2570C9E234E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A2F4F3C5-3A87-4D4C-8CF2-2570C9E234E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A2F4F3C5-3A87-4D4C-8CF2-2570C9E234E1}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- inject dependencies into `EmbeddingService`
- wrap Qdrant client and ONNX inference in new interfaces
- register the wrappers in the embedding service host
- add NUnit test project for `EmbeddingService`

## Testing
- `dotnet test tests/backend/AzurePhotoFlow.EmbeddingService.Tests/AzurePhotoFlow.EmbeddingService.Tests.csproj`
- `dotnet test tests/backend/backend.tests.sln` *(fails: Build errors in AzurePhotoFlow.Api.Tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac98eaa08329b3846a9f11e3ea62