### PR TITLE
Improve inference config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AzurePhotoFlow utilizes a modern cloud architecture with the following key compo
 - Git
 - The environment variable `EMBEDDING_SERVICE_URL` should point to the HTTP endpoint of your embedding service (e.g. `http://embedding:80/api/Embedding`).
 - The embedding service itself requires `QDRANT_URL`, `QDRANT_COLLECTION`, and `CLIP_MODEL_PATH` to be configured.
+- `CLIP_MODEL_PATH` must reference a valid ONNX model file accessible to the backend container. If this file is missing, the backend will fail to start with an *Inference service is not configured* error.
 
 ### Backend Setup
 ```bash

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -137,11 +137,7 @@ builder.Services.AddSingleton(_ =>
     return new QdrantClient(url);
 });
 
-builder.Services.AddSingleton(_ =>
-{
-    string modelPath = Environment.GetEnvironmentVariable("CLIP_MODEL_PATH") ?? "model.onnx";
-    return new InferenceSession(modelPath);
-});
+builder.Services.AddSingleton(_ => InferenceSessionFactory.Create());
 
 // Secure Blob Client Initialization
 /* builder.Services.AddSingleton(x => */

--- a/backend/AzurePhotoFlow.Api/Services/InferenceSessionFactory.cs
+++ b/backend/AzurePhotoFlow.Api/Services/InferenceSessionFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.ML.OnnxRuntime;
+
+namespace AzurePhotoFlow.Services;
+
+public static class InferenceSessionFactory
+{
+    public static InferenceSession Create()
+    {
+        var modelPath = Environment.GetEnvironmentVariable("CLIP_MODEL_PATH");
+        if (string.IsNullOrEmpty(modelPath) || !File.Exists(modelPath))
+        {
+            throw new InvalidOperationException("Inference service is not configured. Set CLIP_MODEL_PATH to a valid ONNX model path.");
+        }
+        return new InferenceSession(modelPath);
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/InferenceSessionFactoryTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/InferenceSessionFactoryTests.cs
@@ -1,0 +1,22 @@
+using AzurePhotoFlow.Services;
+using NUnit.Framework;
+
+namespace unitTests;
+
+[TestFixture]
+public class InferenceSessionFactoryTests
+{
+    [Test]
+    public void Create_WithMissingModelPath_Throws()
+    {
+        Environment.SetEnvironmentVariable("CLIP_MODEL_PATH", null);
+        Assert.Throws<InvalidOperationException>(() => InferenceSessionFactory.Create());
+    }
+
+    [Test]
+    public void Create_WithNonexistentModelPath_Throws()
+    {
+        Environment.SetEnvironmentVariable("CLIP_MODEL_PATH", "/tmp/nonexistent.onnx");
+        Assert.Throws<InvalidOperationException>(() => InferenceSessionFactory.Create());
+    }
+}


### PR DESCRIPTION
## Summary
- add `InferenceSessionFactory` to validate `CLIP_MODEL_PATH`
- use the factory in `Program.cs`
- document inference setup in README
- test factory behaviour when model path is missing or invalid

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842efd9d2b88329ac779fbc34035cff