### PR TITLE
Add Python venv setup script

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,19 @@
+# Local Setup
+
+This project includes a small Python script used to export the CLIP model to ONNX format. The script depends on packages such as **torch** and **transformers**. To keep these dependencies isolated, create a Python virtual environment.
+
+```bash
+# Create the virtual environment and install requirements
+python scripts/setup_venv.py --path .venv
+
+# Activate the environment (Linux/macOS)
+source .venv/bin/activate
+# Windows
+#.venv\Scripts\activate
+```
+
+Once activated, you can run the helper script:
+
+```bash
+python scripts/export_clip_onnx.py --output models/model.onnx
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch
+transformers

--- a/scripts/setup_venv.py
+++ b/scripts/setup_venv.py
@@ -1,0 +1,38 @@
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def create_venv(path: str = "venv", requirements: str = "requirements.txt") -> None:
+    """Create a Python virtual environment and install dependencies.
+
+    Parameters
+    ----------
+    path : str, optional
+        Directory where the virtual environment will be created.
+    requirements : str, optional
+        Path to the requirements file to install.
+    """
+    venv_path = Path(path)
+    subprocess.check_call([sys.executable, "-m", "venv", str(venv_path)])
+    pip_executable = venv_path / ("Scripts" if os.name == "nt" else "bin") / "pip"
+    subprocess.check_call([str(pip_executable), "install", "-r", requirements])
+    print(f"Virtual environment created at {venv_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Setup Python virtual environment")
+    parser.add_argument("--path", default="venv", help="Directory for the virtual environment")
+    parser.add_argument(
+        "--requirements",
+        default="requirements.txt",
+        help="Path to requirements.txt",
+    )
+    args = parser.parse_args()
+    create_venv(args.path, args.requirements)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_setup_venv.py
+++ b/tests/scripts/test_setup_venv.py
@@ -1,0 +1,27 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+import tempfile
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SETUP_PATH = os.path.join(ROOT_DIR, "scripts", "setup_venv.py")
+
+spec = importlib.util.spec_from_file_location("scripts.setup_venv", SETUP_PATH)
+setup_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(setup_mod)
+
+
+def test_create_venv_runs_expected_commands():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with mock.patch.object(setup_mod.subprocess, "check_call") as mock_call:
+            setup_mod.create_venv(tmpdir, "req.txt")
+
+            pip = Path(tmpdir) / ("Scripts" if os.name == "nt" else "bin") / "pip"
+            expected_calls = [
+                mock.call([sys.executable, "-m", "venv", tmpdir]),
+                mock.call([str(pip), "install", "-r", "req.txt"]),
+            ]
+            assert mock_call.mock_calls == expected_calls


### PR DESCRIPTION
## Summary
- provide `requirements.txt` and script for setting up a Python venv
- document how to create a virtual environment in `docs/setup.md`
- add tests for new `setup_venv` script

## Testing
- `pytest -q tests/scripts/test_export_clip_onnx.py tests/scripts/test_setup_venv.py`
- `dotnet test tests/backend/backend.tests.sln --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843399389ac8329bb41aadd53a647d7