### PR TITLE
Refactor embedding service and add vector store tests

### DIFF
--- a/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using System.IO.Compression;
 using AzurePhotoFlow.Shared;
-using System.Collections.Generic;
 
 namespace AzurePhotoFlow.Services;
 
@@ -12,10 +11,12 @@ namespace AzurePhotoFlow.Services;
 public class EmbeddingController : ControllerBase
 {
     private readonly IEmbeddingService _embeddingService;
+    private readonly IVectorStore _vectorStore;
 
-    public EmbeddingController(IEmbeddingService embeddingService)
+    public EmbeddingController(IEmbeddingService embeddingService, IVectorStore vectorStore)
     {
         _embeddingService = embeddingService;
+        _vectorStore = vectorStore;
     }
 
     [HttpPost("generate")]
@@ -47,7 +48,8 @@ public class EmbeddingController : ControllerBase
             images.Add(new ImageEmbeddingInput(objectKey, ms.ToArray()));
         }
 
-        await _embeddingService.GenerateAsync(images);
+        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(images);
+        await _vectorStore.UpsertAsync(embeddings);
         return Ok();
     }
 

--- a/backend/AzurePhotoFlow.Api/Interfaces/IEmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Interfaces/IEmbeddingService.cs
@@ -5,5 +5,5 @@ namespace Api.Interfaces;
 
 public interface IEmbeddingService
 {
-    Task GenerateAsync(IEnumerable<ImageEmbeddingInput> images);
+    Task<IEnumerable<ImageEmbedding>> GenerateEmbeddingsAsync(IEnumerable<ImageEmbeddingInput> images);
 }

--- a/backend/AzurePhotoFlow.Api/Interfaces/IVectorStore.cs
+++ b/backend/AzurePhotoFlow.Api/Interfaces/IVectorStore.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace AzurePhotoFlow.Services;
+
+public interface IVectorStore
+{
+    Task UpsertAsync(IEnumerable<ImageEmbedding> embeddings);
+}

--- a/backend/AzurePhotoFlow.Api/Models/ImageEmbedding.cs
+++ b/backend/AzurePhotoFlow.Api/Models/ImageEmbedding.cs
@@ -1,0 +1,6 @@
+namespace AzurePhotoFlow.Services;
+
+/// <summary>
+/// Represents an embedding vector associated with an image key.
+/// </summary>
+public record ImageEmbedding(string ObjectKey, float[] Vector);

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -188,6 +188,7 @@ builder.Services.AddSingleton(_ =>
 builder.Services.AddScoped<IMetadataExtractorService, MetadataExtractorService>();
 builder.Services.AddScoped<IImageUploadService, MinIOImageUploadService>();
 builder.Services.AddSingleton<IQdrantClientWrapper, QdrantClientWrapper>();
+builder.Services.AddSingleton<IVectorStore, QdrantVectorStore>();
 builder.Services.AddSingleton<IImageEmbeddingModel>(sp =>
 {
     var session = sp.GetRequiredService<InferenceSession>();

--- a/backend/AzurePhotoFlow.Api/Services/EmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/EmbeddingService.cs
@@ -1,42 +1,27 @@
 using Api.Interfaces;
 using Microsoft.Extensions.Logging;
-using Qdrant.Client.Grpc;
-using System.Collections.Generic;
-using System.Linq;
-using AzurePhotoFlow.Services;
-using Google.Protobuf.Collections;
-using QdrantValue = Qdrant.Client.Grpc.Value;
 
 namespace AzurePhotoFlow.Services;
 
 public class EmbeddingService : IEmbeddingService
 {
-    private readonly IQdrantClientWrapper _qdrantClient;
     private readonly ILogger<EmbeddingService> _logger;
     private readonly IImageEmbeddingModel _embeddingModel;
-    private readonly string _collection;
 
-    public EmbeddingService(IQdrantClientWrapper qdrantClient, ILogger<EmbeddingService> logger, IImageEmbeddingModel embeddingModel)
+    public EmbeddingService(ILogger<EmbeddingService> logger, IImageEmbeddingModel embeddingModel)
     {
-        _qdrantClient = qdrantClient;
         _logger = logger;
         _embeddingModel = embeddingModel;
-        _collection = Environment.GetEnvironmentVariable("QDRANT_COLLECTION") ?? "images";
     }
 
-    public async Task GenerateAsync(IEnumerable<ImageEmbeddingInput> images)
+    public Task<IEnumerable<ImageEmbedding>> GenerateEmbeddingsAsync(IEnumerable<ImageEmbeddingInput> images)
     {
-        foreach (var image in images)
+        var embeddings = images.Select(i =>
         {
-            float[] vector = _embeddingModel.GenerateEmbedding(image.ImageBytes);
+            var vector = _embeddingModel.GenerateEmbedding(i.ImageBytes);
+            return new ImageEmbedding(i.ObjectKey, vector);
+        }).ToList();
 
-            var point = new PointStruct
-            {
-                Id = new PointId { Uuid = image.ObjectKey },
-                Vectors = vector
-            };
-            point.Payload.Add("path", new QdrantValue { StringValue = image.ObjectKey });
-            await _qdrantClient.UpsertAsync(_collection, new[] { point });
-        }
+        return Task.FromResult<IEnumerable<ImageEmbedding>>(embeddings);
     }
 }

--- a/backend/AzurePhotoFlow.Api/Services/QdrantVectorStore.cs
+++ b/backend/AzurePhotoFlow.Api/Services/QdrantVectorStore.cs
@@ -1,0 +1,32 @@
+using Qdrant.Client.Grpc;
+using System.Linq;
+using QdrantValue = Qdrant.Client.Grpc.Value;
+
+namespace AzurePhotoFlow.Services;
+
+public class QdrantVectorStore : IVectorStore
+{
+    private readonly IQdrantClientWrapper _client;
+    private readonly string _collection;
+
+    public QdrantVectorStore(IQdrantClientWrapper client)
+    {
+        _client = client;
+        _collection = Environment.GetEnvironmentVariable("QDRANT_COLLECTION") ?? "images";
+    }
+
+    public async Task UpsertAsync(IEnumerable<ImageEmbedding> embeddings)
+    {
+        var points = embeddings.Select(e =>
+        {
+            var point = new PointStruct
+            {
+                Id = new PointId { Uuid = e.ObjectKey },
+                Vectors = e.Vector
+            };
+            point.Payload.Add("path", new QdrantValue { StringValue = e.ObjectKey });
+            return point;
+        });
+        await _client.UpsertAsync(_collection, points);
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingServiceTests.cs
@@ -1,0 +1,35 @@
+using Api.Interfaces;
+using AzurePhotoFlow.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace unitTests;
+
+[TestFixture]
+public class EmbeddingServiceTests
+{
+    [Test]
+    public async Task GenerateEmbeddingsAsync_ReturnsVectors()
+    {
+        var mockModel = new Mock<IImageEmbeddingModel>();
+        mockModel.Setup(m => m.GenerateEmbedding(It.IsAny<byte[]>())).Returns(new float[] { 0.5f });
+
+        var logger = new Mock<ILogger<EmbeddingService>>();
+        var service = new EmbeddingService(logger.Object, mockModel.Object);
+
+        var inputs = new List<ImageEmbeddingInput>
+        {
+            new ImageEmbeddingInput("img", new byte[] {1,2})
+        };
+
+        var result = await service.GenerateEmbeddingsAsync(inputs);
+
+        var embedding = result.Single();
+        Assert.AreEqual("img", embedding.ObjectKey);
+        Assert.AreEqual(0.5f, embedding.Vector[0]);
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
@@ -1,0 +1,36 @@
+using AzurePhotoFlow.Services;
+using Moq;
+using NUnit.Framework;
+using Qdrant.Client.Grpc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace unitTests;
+
+[TestFixture]
+public class VectorStoreTests
+{
+    [Test]
+    public async Task UpsertAsync_DelegatesToClientWrapper()
+    {
+        var mockWrapper = new Mock<IQdrantClientWrapper>();
+        IEnumerable<PointStruct>? received = null;
+        mockWrapper.Setup(w => w.UpsertAsync(It.IsAny<string>(), It.IsAny<IEnumerable<PointStruct>>()))
+            .Callback<string, IEnumerable<PointStruct>>((c, pts) => received = pts)
+            .Returns(Task.CompletedTask);
+
+        var store = new QdrantVectorStore(mockWrapper.Object);
+        var embeddings = new List<ImageEmbedding>
+        {
+            new ImageEmbedding("key", new float[] { 1f })
+        };
+
+        await store.UpsertAsync(embeddings);
+
+        Assert.NotNull(received);
+        var point = received!.Single();
+        Assert.AreEqual("key", point.Id.Uuid);
+        Assert.AreEqual("key", point.Payload["path"].StringValue);
+    }
+}


### PR DESCRIPTION
## Summary
- decouple vector storage from EmbeddingService
- add `IVectorStore` and `QdrantVectorStore` implementations
- adjust controllers to store embeddings using the new service
- provide new model `ImageEmbedding`
- update unit tests and add coverage for new services

## Testing
- `dotnet test tests/backend/AzurePhotoFlow.Api.Tests/AzurePhotoFlow.Api.Tests.csproj -v m` *(fails: 8 failed, 10 passed)*
- `dotnet test tests/backend/backend.tests.sln` *(fails: 8 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff6ab620832996b8bc4a62813387