### PR TITLE
Implement streaming for embedding generation

### DIFF
--- a/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
@@ -33,22 +33,27 @@ public class EmbeddingController : ControllerBase
         string destDir = request.IsRawFiles ? request.DirectoryName : request.RawDirectoryName;
         string destinationPrefix = MinIODirectoryHelper.GetDestinationPath(request.Timestamp, request.ProjectName, destDir, request.IsRawFiles);
 
-        var images = new List<ImageEmbeddingInput>();
-
-        foreach (var entry in archive.Entries)
+        async IAsyncEnumerable<ImageEmbeddingInput> GetImages()
         {
-            if (!MinIODirectoryHelper.IsDirectDescendant(entry, request.DirectoryName) ||
-                !MinIODirectoryHelper.IsImageFile(entry.Name))
-                continue;
+            foreach (var entry in archive.Entries)
+            {
+                if (!MinIODirectoryHelper.IsDirectDescendant(entry, request.DirectoryName) ||
+                    !MinIODirectoryHelper.IsImageFile(entry.Name))
+                    continue;
 
-            await using var entryStream = entry.Open();
-            using var ms = new MemoryStream();
-            await entryStream.CopyToAsync(ms);
-            string objectKey = $"{destinationPrefix}/{MinIODirectoryHelper.GetRelativePath(entry.FullName, request.DirectoryName)}";
-            images.Add(new ImageEmbeddingInput(objectKey, ms.ToArray()));
+                await using var entryStream = entry.Open();
+                using var ms = new MemoryStream();
+                await entryStream.CopyToAsync(ms);
+                string objectKey = $"{destinationPrefix}/{MinIODirectoryHelper.GetRelativePath(entry.FullName, request.DirectoryName)}";
+                yield return new ImageEmbeddingInput(objectKey, ms.ToArray());
+            }
         }
 
-        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(images);
+        var embeddings = new List<ImageEmbedding>();
+        await foreach (var e in _embeddingService.GenerateEmbeddingsAsync(GetImages()))
+        {
+            embeddings.Add(e);
+        }
         await _vectorStore.UpsertAsync(embeddings);
         return Ok();
     }

--- a/backend/AzurePhotoFlow.Api/Interfaces/IEmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Interfaces/IEmbeddingService.cs
@@ -5,5 +5,5 @@ namespace Api.Interfaces;
 
 public interface IEmbeddingService
 {
-    Task<IEnumerable<ImageEmbedding>> GenerateEmbeddingsAsync(IEnumerable<ImageEmbeddingInput> images);
+    IAsyncEnumerable<ImageEmbedding> GenerateEmbeddingsAsync(IAsyncEnumerable<ImageEmbeddingInput> images);
 }

--- a/backend/AzurePhotoFlow.Api/Services/EmbeddingService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/EmbeddingService.cs
@@ -14,14 +14,12 @@ public class EmbeddingService : IEmbeddingService
         _embeddingModel = embeddingModel;
     }
 
-    public Task<IEnumerable<ImageEmbedding>> GenerateEmbeddingsAsync(IEnumerable<ImageEmbeddingInput> images)
+    public async IAsyncEnumerable<ImageEmbedding> GenerateEmbeddingsAsync(IAsyncEnumerable<ImageEmbeddingInput> images)
     {
-        var embeddings = images.Select(i =>
+        await foreach (var i in images)
         {
             var vector = _embeddingModel.GenerateEmbedding(i.ImageBytes);
-            return new ImageEmbedding(i.ObjectKey, vector);
-        }).ToList();
-
-        return Task.FromResult<IEnumerable<ImageEmbedding>>(embeddings);
+            yield return new ImageEmbedding(i.ObjectKey, vector);
+        }
     }
 }

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingServiceTests.cs
@@ -26,9 +26,13 @@ public class EmbeddingServiceTests
             new ImageEmbeddingInput("img", new byte[] {1,2})
         };
 
-        var result = await service.GenerateEmbeddingsAsync(inputs);
+        var results = new List<ImageEmbedding>();
+        await foreach(var e in service.GenerateEmbeddingsAsync(inputs.ToAsyncEnumerable()))
+        {
+            results.Add(e);
+        }
 
-        var embedding = result.Single();
+        var embedding = results.Single();
         Assert.AreEqual("img", embedding.ObjectKey);
         Assert.AreEqual(0.5f, embedding.Vector[0]);
     }


### PR DESCRIPTION
## Summary
- stream input images from zip archives
- stream image embeddings from the embedding service
- update controllers to gather streamed results
- adjust unit tests to work with async streams

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684803f4d8f883299719db78b63a6dc3