### PR TITLE
Add local MinIO service

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ dotnet build
 dotnet run
 ```
 
+### Docker Compose
+To start all services including MinIO and Qdrant locally, use:
+
+```bash
+docker compose up
+```
+
+MinIO will be available at `http://localhost:9000` with the console at `http://localhost:9001` using the default credentials `minioadmin:minioadmin`.
+
 ### Frontend Setup
 ```bash
 # Navigate to the frontend directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
         CERTIFICATE_PATH: ${CERTIFICATE_PATH}
         JWT_SECRET_KEY: ${JWT_SECRET_KEY}
         MODE: ${MODE}
-        MINIO_ENDPOINT: ${MINIO_ENDPOINT}
-        MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
-        MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+        MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+        MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
+        MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
     container_name: backend
     volumes:
       - ./models:/models
@@ -36,15 +36,30 @@ services:
       - MODE=${MODE}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
-      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://minio:9000}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
       - QDRANT_URL=${QDRANT_URL}
       - QDRANT_COLLECTION=${QDRANT_COLLECTION}
       - CLIP_MODEL_PATH=${CLIP_MODEL_PATH:-/models/model.onnx}
     networks:
       - app-network
+    depends_on:
+      - minio
 
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minioadmin}
+    command: server /data --console-address ":9001"
+    networks:
+      - app-network
 
   qdrant:
     image: qdrant/qdrant:latest
@@ -73,3 +88,6 @@ services:
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  minio-data:

--- a/tests/backend/AzurePhotoFlow.Api.Tests/IntegrationTests/MinioConnectionTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/IntegrationTests/MinioConnectionTests.cs
@@ -1,0 +1,47 @@
+using Minio;
+using NUnit.Framework;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace integrationTests;
+
+[TestFixture]
+public class MinioConnectionTests
+{
+    private static string Endpoint => Environment.GetEnvironmentVariable("MINIO_ENDPOINT") ?? "http://localhost:9000";
+    private static string AccessKey => Environment.GetEnvironmentVariable("MINIO_ACCESS_KEY") ?? "minioadmin";
+    private static string SecretKey => Environment.GetEnvironmentVariable("MINIO_SECRET_KEY") ?? "minioadmin";
+
+    private static async Task<bool> IsMinioRunning()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+            var resp = await http.GetAsync($"{Endpoint.TrimEnd('/')}/minio/health/live");
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [Test]
+    public async Task ListBuckets_WhenMinioRunning_ReturnsResult()
+    {
+        if (!await IsMinioRunning())
+        {
+            Assert.Ignore("MinIO service not running");
+        }
+
+        var client = new MinioClient()
+            .WithEndpoint(Endpoint)
+            .WithCredentials(AccessKey, SecretKey)
+            .Build();
+
+        var buckets = await client.ListBucketsAsync();
+        Assert.IsNotNull(buckets);
+    }
+}
+


### PR DESCRIPTION
## Summary
- include MinIO service in docker-compose with default credentials
- expose ports and mount a volume
- update backend to use defaults and depend on MinIO
- document docker compose usage and MinIO info
- add integration test verifying MinIO connectivity

## Testing
- `dotnet test` *(fails: 8 failed, 10 passed, 1 skipped)*
- `npm test` *(fails: vitest watch mode could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_684803c1d9c08329a097d27e3a540acb