### PR TITLE
Fix timestamp parsing for uploads

### DIFF
--- a/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
@@ -167,15 +167,17 @@ public class ImageController : ControllerBase
         {
             _logger.LogInformation("Getting projects");
 
-            // Validate and parse timestamp if provided
+            // Validate and parse timestamp if provided. The client may send the
+            // date in various formats (e.g. from a browser date picker).  Try a
+            // general parse and normalise to a date-only value.
             DateTime? parsedTimestamp = null;
             if (!string.IsNullOrEmpty(timestamp))
             {
-                if (!DateTime.TryParseExact(timestamp, "yyyy-MM-dd", null, DateTimeStyles.None, out var validDate))
+                if (!DateTime.TryParse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var validDate))
                 {
                     return BadRequest("Invalid timestamp format. Use 'yyyy-MM-dd'.");
                 }
-                parsedTimestamp = validDate;
+                parsedTimestamp = validDate.Date;
             }
 
             var projects = await _imageUploadService.GetProjectsAsync(year, projectName, parsedTimestamp);

--- a/frontend/src/components/ImageUpload.jsx
+++ b/frontend/src/components/ImageUpload.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import JSZip from 'jszip'; // Import JSZip for zipping files
 import '../styles/ImageUpload.css';
 import { uploadRawDirectory } from '../services/imageUploadApi';
+import { formatDate } from '../utils/formatDate';
 
 const ImageUpload = () => {
     const [isZipUpload, setIsZipUpload] = useState(false);
@@ -40,7 +41,13 @@ const handleUpload = async () => {
         return;
     }
 
-    if (!timeStamp || !/^\d{4}-\d{2}-\d{2}$/.test(timeStamp)) {
+    if (!timeStamp) {
+        alert('Timestamp is required.');
+        return;
+    }
+
+    const formattedTimeStamp = formatDate(timeStamp);
+    if (!formattedTimeStamp) {
         alert('Invalid timestamp format. Please use yyyy-MM-dd.');
         return;
     }
@@ -72,7 +79,7 @@ const handleUpload = async () => {
 
     try {
         setUploadStatus('Uploading files...');
-        const response = await uploadRawDirectory(timeStamp, projectName, directoryFile);
+        const response = await uploadRawDirectory(formattedTimeStamp, projectName, directoryFile);
         setUploadStatus('Upload successful!');
         console.log('Upload response:', response);
     } catch (error) {

--- a/frontend/src/utils/formatDate.js
+++ b/frontend/src/utils/formatDate.js
@@ -1,0 +1,7 @@
+export function formatDate(dateString) {
+  const d = new Date(dateString);
+  if (isNaN(d)) {
+    return null;
+  }
+  return d.toISOString().split('T')[0];
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
@@ -1,0 +1,41 @@
+using Api.Interfaces;
+using Api.Models;
+using AzurePhotoFlow.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace unitTests;
+
+[TestFixture]
+public class GetProjectsTimestampTests
+{
+    [Test]
+    public async Task GetProjects_ValidTimestamp_ParsesDate()
+    {
+        var mockService = new Mock<IImageUploadService>();
+        mockService.Setup(s => s.GetProjectsAsync(null, null, It.IsAny<DateTime?>()))
+            .ReturnsAsync(new List<ProjectInfo>());
+
+        var controller = new ImageController(new Mock<ILogger<ImageController>>().Object,
+            mockService.Object, new Mock<IEmbeddingService>().Object, new Mock<IVectorStore>().Object);
+
+        var result = await controller.GetProjects(null, null, "01/02/2025");
+        Assert.IsInstanceOf<OkObjectResult>(result);
+        mockService.Verify(s => s.GetProjectsAsync(null, null, It.Is<DateTime?>(d => d!.Value.Year == 2025 && d.Value.Month == 1 && d.Value.Day == 2)), Times.Once);
+    }
+
+    [Test]
+    public async Task GetProjects_InvalidTimestamp_ReturnsBadRequest()
+    {
+        var controller = new ImageController(new Mock<ILogger<ImageController>>().Object,
+            new Mock<IImageUploadService>().Object, new Mock<IEmbeddingService>().Object, new Mock<IVectorStore>().Object);
+
+        var result = await controller.GetProjects(null, null, "notadate");
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+}

--- a/tests/frontend/unit/formatDate.test.js
+++ b/tests/frontend/unit/formatDate.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '@frontend/utils/formatDate.js';
+
+describe('formatDate', () => {
+  it('returns ISO date string', () => {
+    expect(formatDate('2024-05-20')).toBe('2024-05-20');
+  });
+
+  it('returns null for invalid date', () => {
+    expect(formatDate('invalid')).toBeNull();
+  });
+});

--- a/tests/frontend/vitest.config.js
+++ b/tests/frontend/vitest.config.js
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@frontend': path.resolve(__dirname, '../../frontend/src'),
+    },
+  },
   test: {
     globals: true,         // Enables global test functions like `describe`, `test`, etc.
     environment: 'jsdom',  // Simulates browser-like environment for React


### PR DESCRIPTION
## Summary
- allow flexible timestamp parsing in `GetProjects`
- upload form formats date consistently using new helper
- add tests for timestamp logic
- configure Vitest to resolve project src

## Testing
- `npm test --silent` *(fails: vitest not installed)*
- `npm test --silent` in `tests/frontend`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684811b5578c8329be74fc51f5286672