### PR TITLE
Add configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AzurePhotoFlow utilizes a modern cloud architecture with the following key compo
 - Git
 - The environment variable `EMBEDDING_SERVICE_URL` should point to the HTTP endpoint of your embedding service (e.g. `http://embedding:80/api/Embedding`).
 - The embedding service itself requires `QDRANT_URL`, `QDRANT_COLLECTION`, and `CLIP_MODEL_PATH` to be configured.
+- `ALLOWED_ORIGINS` (optional): comma-separated list of origins allowed by the backend CORS policy. Defaults to `http://localhost`.
 
 ### Exporting the CLIP Model
 The backend expects an ONNX version of the CLIP vision model. You can export it using the provided helper script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,7 @@ stages:
           echo "CONTAINER_REGISTRY=$(containerRegistry)" > .env
           echo "VITE_API_BASE_URL=$(VITE_API_BASE_URL)"  >> .env
           echo "stableTag=$(Build.BuildId)" >> .env
+          echo "ALLOWED_ORIGINS=$(ALLOWED_ORIGINS)" >> .env
         displayName: 'Create .env file'
 
       - publish: $(Build.SourcesDirectory)/.env

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -58,12 +58,13 @@ builder.Services.AddHealthChecks();
 /*         } */
 /*     }); */
 
+var allowedOrigins = CorsConfigHelper.GetAllowedOrigins();
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowSpecificOrigin", policyBuilder =>
     {
-        // Adjust the allowed origin to match your frontend (e.g., including the correct port if needed)
-        policyBuilder.WithOrigins("http://localhost:80", "http://localhost")
+        policyBuilder.WithOrigins(allowedOrigins)
             .AllowAnyMethod()
             .AllowAnyHeader()
             .AllowCredentials();

--- a/backend/AzurePhotoFlow.Api/Services/CorsConfigHelper.cs
+++ b/backend/AzurePhotoFlow.Api/Services/CorsConfigHelper.cs
@@ -1,0 +1,14 @@
+namespace AzurePhotoFlow.Services;
+
+public static class CorsConfigHelper
+{
+    public static string[] GetAllowedOrigins()
+    {
+        var origins = Environment.GetEnvironmentVariable("ALLOWED_ORIGINS");
+        if (string.IsNullOrWhiteSpace(origins))
+        {
+            return new[] { "http://localhost" };
+        }
+        return origins.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - QDRANT_URL=${QDRANT_URL}
       - QDRANT_COLLECTION=${QDRANT_COLLECTION}
       - CLIP_MODEL_PATH=${CLIP_MODEL_PATH:-/models/model.onnx}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost}
     networks:
       - app-network
     depends_on:

--- a/tests/backend/AzurePhotoFlow.Api.Tests/AzurePhotoFlow.Api.Tests.csproj
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/AzurePhotoFlow.Api.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
@@ -1,0 +1,80 @@
+using System.Net.Http;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using AzurePhotoFlow.Services;
+
+namespace unitTests;
+
+[TestFixture]
+public class CorsTests
+{
+    [TearDown]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable("ALLOWED_ORIGINS", null);
+    }
+
+    [Test]
+    public async Task AllowedOrigin_ReturnsCorsHeader()
+    {
+        Environment.SetEnvironmentVariable("ALLOWED_ORIGINS", "http://allowed.com");
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Options, "/");
+        request.Headers.Add("Origin", "http://allowed.com");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        var response = await client.SendAsync(request);
+
+        Assert.IsTrue(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var values));
+        Assert.AreEqual("http://allowed.com", values.First());
+    }
+
+    [Test]
+    public async Task DisallowedOrigin_DoesNotReturnCorsHeader()
+    {
+        Environment.SetEnvironmentVariable("ALLOWED_ORIGINS", "http://allowed.com");
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Options, "/");
+        request.Headers.Add("Origin", "http://other.com");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        var response = await client.SendAsync(request);
+
+        Assert.IsFalse(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    private static TestServer CreateServer()
+    {
+        var builder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                var origins = CorsConfigHelper.GetAllowedOrigins();
+                services.AddCors(options =>
+                {
+                    options.AddPolicy("AllowSpecificOrigin", policy =>
+                    {
+                        policy.WithOrigins(origins)
+                            .AllowAnyMethod()
+                            .AllowAnyHeader()
+                            .AllowCredentials();
+                    });
+                });
+            })
+            .Configure(app =>
+            {
+                app.UseCors("AllowSpecificOrigin");
+                app.Run(async ctx => await ctx.Response.WriteAsync("ok"));
+            });
+
+        return new TestServer(builder);
+    }
+}


### PR DESCRIPTION
## Summary
- make allowed origins configurable for backend CORS
- implement `CorsConfigHelper` to parse `ALLOWED_ORIGINS`
- document the new setting
- update docker compose and pipeline to pass `ALLOWED_ORIGINS`
- add unit tests covering allowed and disallowed origins

## Testing
- `dotnet test tests/backend/AzurePhotoFlow.Api.Tests/AzurePhotoFlow.Api.Tests.csproj --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487db500908329a3b77c751d2bcbb7