### PR TITLE
Update docs and tests for trace script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ AzurePhotoFlow utilizes a modern cloud architecture with the following key compo
 - `ALLOWED_ORIGINS` (optional): comma-separated list of origins allowed by the backend CORS policy. Defaults to `http://localhost`.
 
 ### Exporting the CLIP Model
-The backend expects an ONNX version of the CLIP vision model. You can export it using the provided helper script:
+The backend expects a TorchScript version of the CLIP vision model. You can export it using the provided helper script:
 
 ```bash
-python scripts/export_clip_onnx.py --output models/model.onnx
+python scripts/export_clip_trace.py --output models/clip_vision_traced.pt
 ```
-This will download the pre-trained model and save the ONNX file under `models/`. The `docker-compose.yml` mounts this directory so the backend container can access the model at `/models/model.onnx`.
+This will download the pre-trained model and save the TorchScript file under `models/`. The `docker-compose.yml` mounts this directory so the backend container can access the model at `/models/clip_vision_traced.pt`.
 
 ### Backend Setup
 ```bash

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Local Setup
 
-This project includes a small Python script used to export the CLIP model to ONNX format. The script depends on packages such as **torch** and **transformers**. To keep these dependencies isolated, create a Python virtual environment.
+This project includes a small Python script used to export the CLIP model to TorchScript format. The script depends on packages such as **torch** and **transformers**. To keep these dependencies isolated, create a Python virtual environment.
 
 ```bash
 # Create the virtual environment and install requirements
@@ -15,5 +15,5 @@ source .venv/bin/activate
 Once activated, you can run the helper script:
 
 ```bash
-python scripts/export_clip_onnx.py --output models/model.onnx
+python scripts/export_clip_trace.py --output models/clip_vision_traced.pt
 ```

--- a/tests/scripts/test_export_clip_trace.py
+++ b/tests/scripts/test_export_clip_trace.py
@@ -6,16 +6,16 @@ import os
 import sys
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-EXPORT_PATH = os.path.join(ROOT_DIR, "scripts", "export_clip_onnx.py")
+EXPORT_PATH = os.path.join(ROOT_DIR, "scripts", "export_clip_trace.py")
 
-spec = importlib.util.spec_from_file_location("scripts.export_clip_onnx", EXPORT_PATH)
+spec = importlib.util.spec_from_file_location("scripts.export_clip_trace", EXPORT_PATH)
 exp = importlib.util.module_from_spec(spec)
 with mock.patch.dict(sys.modules, {"torch": mock.Mock(), "transformers": mock.Mock()}):
     assert spec.loader is not None
     spec.loader.exec_module(exp)
 
 
-def test_export_calls_torch_export():
+def test_export_calls_torch_trace():
     with tempfile.NamedTemporaryFile() as tmp:
         with mock.patch.object(exp, "CLIPModel") as mock_model_cls, \
              mock.patch.object(exp, "torch") as mock_torch:
@@ -23,8 +23,12 @@ def test_export_calls_torch_export():
             model_instance.vision_model = object()
             mock_model_cls.from_pretrained.return_value = model_instance
 
+            trace_result = mock.Mock()
+            mock_torch.jit.trace.return_value = trace_result
+
             exp.export_clip_model(tmp.name, model_name="a/b")
 
-            mock_model_cls.from_pretrained.assert_called_with("a/b")
-            assert mock_torch.onnx.export.called
+            mock_model_cls.from_pretrained.assert_called_with("a/b", use_safetensors=True)
+            assert mock_torch.jit.trace.called
+            assert trace_result.save.called
 


### PR DESCRIPTION
## Summary
- reference `export_clip_trace.py` instead of the old ONNX helper
- adjust setup docs accordingly
- update Python tests to load the new script
- fix virtualenv test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c996ad5c832990803f67c0a985d5