### PR TITLE
Improve ONNX export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,20 @@ AzurePhotoFlow utilizes a modern cloud architecture with the following key compo
 - `ALLOWED_ORIGINS` (optional): comma-separated list of origins allowed by the backend CORS policy. Defaults to `http://localhost`.
 
 ### Exporting the CLIP Model
-The backend expects an ONNX version of the CLIP vision model. You can export it using the provided helper script:
+The backend expects an ONNX version of the CLIP vision model. Create the Python virtual environment first:
+
+```bash
+python scripts/setup_venv.py --path .venv
+source .venv/bin/activate  # on Windows use .venv\Scripts\activate
+```
+
+Then run the helper script to export the model:
 
 ```bash
 python scripts/export_clip_onnx.py --output models/model.onnx
 ```
-This will download the pre-trained model and save the ONNX file under `models/`. The `docker-compose.yml` mounts this directory so the backend container can access the model at `/models/model.onnx`.
+
+This downloads the pre-trained model and saves the ONNX file under `models/`. The `docker-compose.yml` mounts this directory so the backend container can access the model at `/models/model.onnx`.
 
 ### Backend Setup
 ```bash

--- a/scripts/export_clip_onnx.py
+++ b/scripts/export_clip_onnx.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
-"""Utility to export a CLIP vision model to TorchScript (.pt) using tracing."""
+"""Utility to export a CLIP vision model to ONNX."""
 
 import argparse
 import os
 
-# ✅ Use local Hugging Face cache to avoid permission issues
-os.environ["HF_HOME"] = "./.hf_cache"
-
 import torch
 from transformers import CLIPModel
 
+os.environ["HF_HOME"] = "./.hf_cache"
+
+
 def export_clip_model(output_path: str, model_name: str = "openai/clip-vit-base-patch32"):
+    """Export the vision part of a CLIP model to ONNX."""
     print("📥 Loading CLIP model...")
     model = CLIPModel.from_pretrained(model_name, use_safetensors=True)
     model.eval()
-
-    vision_model = model.vision_model
 
     class VisionWrapper(torch.nn.Module):
         def __init__(self, vision_model):
@@ -25,28 +24,31 @@ def export_clip_model(output_path: str, model_name: str = "openai/clip-vit-base-
         def forward(self, pixel_values):
             return self.vision_model(pixel_values).last_hidden_state
 
+    wrapper = VisionWrapper(model.vision_model)
     dummy_input = torch.zeros((1, 3, 224, 224), dtype=torch.float32)
-    wrapper = VisionWrapper(vision_model)
 
-    print("🎥 Tracing the vision model...")
-    traced = torch.jit.trace(wrapper, dummy_input)
-
-    # ✅ Ensure output directory exists
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    print("📤 Exporting to ONNX...")
 
-    print(f"💾 Saving traced model to: {output_path}")
-    traced.save(output_path)
+    torch.onnx.export(
+        wrapper,
+        dummy_input,
+        output_path,
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
+        opset_version=14,
+    )
+    print(f"✅ Model exported to {output_path}")
 
-    print("✅ Export complete (TorchScript format).")
 
 def main():
-    parser = argparse.ArgumentParser(description="Export CLIP vision encoder to TorchScript")
+    parser = argparse.ArgumentParser(description="Export CLIP model to ONNX")
     parser.add_argument("--model", default="openai/clip-vit-base-patch32", help="HuggingFace model name")
-    parser.add_argument("--output", default="models/clip_vision_traced.pt", help="Output path for TorchScript model")
+    parser.add_argument("--output", default="models/model.onnx", help="Output path for ONNX model")
     args = parser.parse_args()
     export_clip_model(args.output, args.model)
 
 
 if __name__ == "__main__":
     main()
-

--- a/tests/scripts/test_export_clip_onnx.py
+++ b/tests/scripts/test_export_clip_onnx.py
@@ -18,13 +18,15 @@ with mock.patch.dict(sys.modules, {"torch": mock.Mock(), "transformers": mock.Mo
 def test_export_calls_torch_export():
     with tempfile.NamedTemporaryFile() as tmp:
         with mock.patch.object(exp, "CLIPModel") as mock_model_cls, \
-             mock.patch.object(exp, "torch") as mock_torch:
+             mock.patch.object(exp, "torch") as mock_torch, \
+             mock.patch.object(exp.os, "makedirs") as mock_makedirs:
             model_instance = mock.Mock()
             model_instance.vision_model = object()
             mock_model_cls.from_pretrained.return_value = model_instance
 
             exp.export_clip_model(tmp.name, model_name="a/b")
 
-            mock_model_cls.from_pretrained.assert_called_with("a/b")
+            mock_model_cls.from_pretrained.assert_called_with("a/b", use_safetensors=True)
             assert mock_torch.onnx.export.called
+            assert mock_makedirs.called
 


### PR DESCRIPTION
## Summary
- enhance `export_clip_onnx.py` to create its output directory and export the model via a wrapper
- document creating the Python virtual environment before running the exporter
- update unit test for the exporter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c996ad5c832990803f67c0a985d5