### PR TITLE
Fix ONNX export for CLIP

### DIFF
--- a/scripts/export_clip_onnx.py
+++ b/scripts/export_clip_onnx.py
@@ -13,7 +13,14 @@ os.environ["HF_HOME"] = "./.hf_cache"
 def export_clip_model(output_path: str, model_name: str = "openai/clip-vit-base-patch32"):
     """Export the vision part of a CLIP model to ONNX."""
     print("📥 Loading CLIP model...")
-    model = CLIPModel.from_pretrained(model_name, use_safetensors=True)
+    # Using the "eager" attention implementation avoids PyTorch's
+    # scaled_dot_product_attention operator which currently fails
+    # during ONNX export.
+    model = CLIPModel.from_pretrained(
+        model_name,
+        use_safetensors=True,
+        attn_implementation="eager",
+    )
     model.eval()
 
     class VisionWrapper(torch.nn.Module):

--- a/tests/scripts/test_export_clip_onnx.py
+++ b/tests/scripts/test_export_clip_onnx.py
@@ -26,7 +26,9 @@ def test_export_calls_torch_export():
 
             exp.export_clip_model(tmp.name, model_name="a/b")
 
-            mock_model_cls.from_pretrained.assert_called_with("a/b", use_safetensors=True)
+            mock_model_cls.from_pretrained.assert_called_with(
+                "a/b", use_safetensors=True, attn_implementation="eager"
+            )
             assert mock_torch.onnx.export.called
             assert mock_makedirs.called
 


### PR DESCRIPTION
## Summary
- disable scaled_dot_product_attention during export to ONNX
- update unit test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dd5ebf048329a0788320e1cf4f10