### PR TITLE
Add configurable JWT issuer and audience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ AzurePhotoFlow is a cloud-native AI-powered photo management application with:
 ### Required Environment Variables
 - `VITE_GOOGLE_CLIENT_ID` - Google OAuth client ID
 - `JWT_SECRET_KEY` - JWT token signing key
+- `JWT_ISSUER` - expected issuer for generated JWT tokens
+- `JWT_AUDIENCE` - expected audience for generated JWT tokens
 - `QDRANT_URL` - Vector database connection
 - `QDRANT_COLLECTION` - Collection name for embeddings
 - `CLIP_MODEL_PATH` - Path to ONNX model file (`/models/model.onnx`)

--- a/backend/AzurePhotoFlow.Api/Models/JwtConfig.cs
+++ b/backend/AzurePhotoFlow.Api/Models/JwtConfig.cs
@@ -1,0 +1,7 @@
+namespace Api.Models;
+
+public class JwtConfig
+{
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+}

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -139,6 +139,8 @@ builder.Services.Configure<FormOptions>(options =>
 
 // Retrieve and Validate Environment Variables
 var jwtSecretKey = Environment.GetEnvironmentVariable("JWT_SECRET_KEY");
+var jwtIssuer = Environment.GetEnvironmentVariable("JWT_ISSUER") ?? "loicportraits.azurewebsites.net";
+var jwtAudience = Environment.GetEnvironmentVariable("JWT_AUDIENCE") ?? "loicportraits.azurewebsites.net";
 var googleClientId = Environment.GetEnvironmentVariable("VITE_GOOGLE_CLIENT_ID");
 
 if (string.IsNullOrEmpty(jwtSecretKey))
@@ -154,6 +156,7 @@ var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecretKey))
 
 builder.Services.AddSingleton(securityKey);
 builder.Services.AddSingleton(new GoogleConfig { ClientId = googleClientId });
+builder.Services.AddSingleton(new JwtConfig { Issuer = jwtIssuer, Audience = jwtAudience });
 builder.Services.AddSingleton<JwtService>();
 
 // Configure JWT Bearer authentication
@@ -163,19 +166,18 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         // Remove or comment out the Google authority since you are not validating Google-issued tokens.
         // options.Authority = "https://accounts.google.com";
 
-        // Set the expected audience and issuer to match the values in your generated JWT.
-        options.Audience = "loicportraits.azurewebsites.net";
+        // Set the expected audience and issuer to match the configured values.
+        options.Audience = jwtAudience;
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = "loicportraits.azurewebsites.net",
+            ValidIssuer = jwtIssuer,
             ValidateAudience = true,
-            ValidAudience = "loicportraits.azurewebsites.net",
+            ValidAudience = jwtAudience,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
             // Use the same secret key that you use to generate your JWT.
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
-                Environment.GetEnvironmentVariable("JWT_SECRET_KEY") ?? string.Empty))
+            IssuerSigningKey = securityKey
         };
 
         // Optional: Add detailed logging to help diagnose authentication failures.

--- a/backend/AzurePhotoFlow.Api/Services/JwtService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/JwtService.cs
@@ -3,15 +3,17 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Tokens;
 
+using Api.Models;
+
 public class JwtService
 {
     private readonly SymmetricSecurityKey _jwtKey;
-    private const string Issuer = "loicportraits.azurewebsites.net";
-    private const string Audience = "loicportraits.azurewebsites.net";
+    private readonly JwtConfig _config;
 
-    public JwtService(SymmetricSecurityKey jwtKey)
+    public JwtService(SymmetricSecurityKey jwtKey, JwtConfig config)
     {
         _jwtKey = jwtKey;
+        _config = config;
     }
 
     public string GenerateJwtToken(string userId, string email)
@@ -28,8 +30,8 @@ public class JwtService
         var creds = new SigningCredentials(_jwtKey, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(
-            issuer: Issuer,
-            audience: Audience,
+            issuer: _config.Issuer,
+            audience: _config.Audience,
             claims: claims,
             expires: DateTime.UtcNow.AddDays(7), // Token valid for 7 days
             signingCredentials: creds

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using AzurePhotoFlow.Services;
 

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace unitTests;
@@ -18,7 +19,7 @@ public class GetProjectsTimestampTests
     public async Task GetProjects_ValidTimestamp_ParsesDate()
     {
         var mockService = new Mock<IImageUploadService>();
-        mockService.Setup(s => s.GetProjectsAsync(null, null, It.IsAny<DateTime?>()))
+        mockService.Setup(s => s.GetProjectsAsync(null, null, It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ProjectInfo>());
 
         var controller = new ImageController(new Mock<ILogger<ImageController>>().Object,
@@ -26,7 +27,7 @@ public class GetProjectsTimestampTests
 
         var result = await controller.GetProjects(null, null, "01/02/2025");
         Assert.IsInstanceOf<OkObjectResult>(result);
-        mockService.Verify(s => s.GetProjectsAsync(null, null, It.Is<DateTime?>(d => d!.Value.Year == 2025 && d.Value.Month == 1 && d.Value.Day == 2)), Times.Once);
+        mockService.Verify(s => s.GetProjectsAsync(null, null, It.Is<DateTime?>(d => d!.Value.Year == 2025 && d.Value.Month == 1 && d.Value.Day == 2), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/JwtServiceTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/JwtServiceTests.cs
@@ -1,0 +1,53 @@
+using Api.Models;
+using AzurePhotoFlow.Services;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Text;
+
+namespace unitTests;
+
+[TestFixture]
+public class JwtServiceTests
+{
+    [Test]
+    public void GenerateJwtToken_UsesConfiguredIssuerAndAudience()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("0123456789abcdef0123456789abcdef"));
+        var config = new JwtConfig { Issuer = "test-issuer", Audience = "test-audience" };
+        var service = new JwtService(key, config);
+
+        var tokenString = service.GenerateJwtToken("user1", "user@test.com");
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(tokenString);
+
+        Assert.AreEqual("test-issuer", token.Issuer);
+        Assert.AreEqual("test-audience", token.Audiences.Single());
+    }
+
+    [Test]
+    public void ValidateToken_WithConfiguredParameters_Succeeds()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("0123456789abcdef0123456789abcdef"));
+        var config = new JwtConfig { Issuer = "test-issuer", Audience = "test-audience" };
+        var service = new JwtService(key, config);
+
+        var tokenString = service.GenerateJwtToken("user1", "user@test.com");
+
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = config.Issuer,
+            ValidateAudience = true,
+            ValidAudience = config.Audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = key,
+            ValidateLifetime = false
+        };
+
+        var handler = new JwtSecurityTokenHandler();
+        handler.ValidateToken(tokenString, parameters, out var validatedToken);
+        Assert.NotNull(validatedToken);
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
@@ -7,6 +7,7 @@ using Qdrant.Client.Grpc;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace unitTests;
 
@@ -22,7 +23,7 @@ public class VectorStoreTests
             .Callback<string, IEnumerable<PointStruct>>((c, pts) => received = pts)
             .Returns(Task.CompletedTask);
 
-        var store = new QdrantVectorStore(mockWrapper.Object);
+        var store = new QdrantVectorStore(new NullLogger<QdrantVectorStore>(), mockWrapper.Object);
         var embeddings = new List<ImageEmbedding>
         {
             new ImageEmbedding("key", new float[] { 1f })


### PR DESCRIPTION
## Summary
- make JWT issuer and audience configurable via env vars
- inject new JwtConfig into JwtService and Program
- document `JWT_ISSUER` and `JWT_AUDIENCE`
- add JwtService unit tests and update existing tests

## Testing
- `dotnet test AzurePhotoFlow.Api.Tests --no-build --filter FullyQualifiedName~JwtServiceTests`
- `dotnet test AzurePhotoFlow.Functions.Tests --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684be1ab178083298764a95e98bd7155