### PR TITLE
Enhance validation and upload result handling

### DIFF
--- a/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/EmbeddingController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using System.IO.Compression;
 using AzurePhotoFlow.Shared;
 using Api.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace AzurePhotoFlow.Services;
 
@@ -68,10 +69,18 @@ public class EmbeddingController : ControllerBase
 
 public class EmbeddingRequest
 {
+    [Required]
     public string ProjectName { get; set; } = string.Empty;
+
+    [Required]
     public string DirectoryName { get; set; } = string.Empty;
+
+    [Required]
     public DateTime Timestamp { get; set; }
+
+    [Required]
     public IFormFile? ZipFile { get; set; }
+
     public bool IsRawFiles { get; set; } = true;
     public string RawDirectoryName { get; set; } = string.Empty;
 }

--- a/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
@@ -45,6 +45,16 @@ public class ImageController : ControllerBase
     [HttpPost("raw")]
     public async Task<IActionResult> UploadDirectory(DateTime timeStamp, string projectName, IFormFile directoryFile)
     {
+        if (timeStamp == default)
+        {
+            return BadRequest("Timestamp must be provided.");
+        }
+
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            return BadRequest("Project name must be provided.");
+        }
+
         if (directoryFile == null || directoryFile.Length == 0)
         {
             return BadRequest("A Zip file must be provided.");
@@ -83,6 +93,21 @@ public class ImageController : ControllerBase
     [HttpPost("processed")]
     public async Task<IActionResult> UploadProcessedFiles(DateTime timeStamp, string projectName, string rawfileDirectoryName, IFormFile directoryFile)
     {
+        if (timeStamp == default)
+        {
+            return BadRequest("Timestamp must be provided.");
+        }
+
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            return BadRequest("Project name must be provided.");
+        }
+
+        if (string.IsNullOrWhiteSpace(rawfileDirectoryName))
+        {
+            return BadRequest("Raw directory name must be provided.");
+        }
+
         if (directoryFile == null || directoryFile.Length == 0)
         {
             return BadRequest("A Zip file must be provided.");

--- a/backend/AzurePhotoFlow.Api/Interfaces/IImageUploadService.cs
+++ b/backend/AzurePhotoFlow.Api/Interfaces/IImageUploadService.cs
@@ -28,7 +28,7 @@ public interface IImageUploadService
     /// <summary>
     /// Uploads a single image from byte array to storage
     /// </summary>
-    Task<bool> UploadImageFromBytesAsync(byte[] imageData, string objectKey, string fileName);
+    Task<ImageUploadResult> UploadImageFromBytesAsync(byte[] imageData, string objectKey, string fileName);
     
     /// <summary>
     /// Optimized method to process zip file once for both embeddings and uploads

--- a/backend/AzurePhotoFlow.Api/Models/GoogleLoginRequest.cs
+++ b/backend/AzurePhotoFlow.Api/Models/GoogleLoginRequest.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Api.Models;
 
 public class GoogleLoginRequest
 {
-    public string Token { get; set; } // Google ID Token
+    [Required]
+    public string Token { get; set; } = string.Empty; // Google ID Token
 }
 

--- a/backend/AzurePhotoFlow.Api/Models/ImageUploadResult.cs
+++ b/backend/AzurePhotoFlow.Api/Models/ImageUploadResult.cs
@@ -1,0 +1,18 @@
+namespace Api.Models;
+
+public class ImageUploadResult
+{
+    public string ObjectKey { get; }
+    public bool Success { get; }
+    public string? ErrorMessage { get; }
+
+    private ImageUploadResult(string objectKey, bool success, string? error)
+    {
+        ObjectKey = objectKey;
+        Success = success;
+        ErrorMessage = error;
+    }
+
+    public static ImageUploadResult Ok(string objectKey) => new ImageUploadResult(objectKey, true, null);
+    public static ImageUploadResult Fail(string objectKey, string error) => new ImageUploadResult(objectKey, false, error);
+}

--- a/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
@@ -439,7 +439,7 @@ private async Task<List<ProjectDirectory>> GetDirectoryDetailsAsync(
         return count;
     }
 
-    public async Task<bool> UploadImageFromBytesAsync(byte[] imageData, string objectKey, string fileName)
+    public async Task<ImageUploadResult> UploadImageFromBytesAsync(byte[] imageData, string objectKey, string fileName)
     {
         try
         {
@@ -470,12 +470,12 @@ private async Task<List<ProjectDirectory>> GetDirectoryDetailsAsync(
             };
 
             _log.LogInformation("Uploaded image: {ObjectKey}", objectKey);
-            return true;
+            return ImageUploadResult.Ok(objectKey);
         }
         catch (Exception ex)
         {
             _log.LogError(ex, "Failed to upload image {ObjectKey}", objectKey);
-            return false;
+            return ImageUploadResult.Fail(objectKey, ex.Message);
         }
     }
 
@@ -494,7 +494,7 @@ private async Task<List<ProjectDirectory>> GetDirectoryDetailsAsync(
         }
 
         var embeddings = new List<ImageEmbeddingInput>();
-        var uploadTasks = new List<Task<bool>>();
+        var uploadTasks = new List<Task<ImageUploadResult>>();
         int totalCount = 0;
 
         string destinationPath = MinIODirectoryHelper.GetDestinationPath(
@@ -549,7 +549,7 @@ private async Task<List<ProjectDirectory>> GetDirectoryDetailsAsync(
 
         // Wait for all uploads to complete
         var uploadResults = await Task.WhenAll(uploadTasks);
-        int uploadedCount = uploadResults.Count(success => success);
+        int uploadedCount = uploadResults.Count(r => r.Success);
 
         var uploadResponse = new UploadResponse 
         { 

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/CorsTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using AzurePhotoFlow.Services;

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingControllerTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/EmbeddingControllerTests.cs
@@ -73,5 +73,24 @@ public class EmbeddingControllerTests
         Assert.AreEqual($"{expectedPrefix}/img.jpg", received[0].ObjectKey);
         CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, received[0].ImageBytes);
     }
+
+    [Test]
+    public async Task Generate_MissingZipFile_ReturnsBadRequest()
+    {
+        var controller = new EmbeddingController(new Mock<IEmbeddingService>().Object,
+                                                 new Mock<IVectorStore>().Object);
+
+        var request = new EmbeddingRequest
+        {
+            ProjectName = "P",
+            DirectoryName = "D",
+            Timestamp = DateTime.UtcNow,
+            ZipFile = null
+        };
+
+        var result = await controller.Generate(request);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
 }
 

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/GetProjectsTimestampTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace unitTests;
@@ -18,7 +19,7 @@ public class GetProjectsTimestampTests
     public async Task GetProjects_ValidTimestamp_ParsesDate()
     {
         var mockService = new Mock<IImageUploadService>();
-        mockService.Setup(s => s.GetProjectsAsync(null, null, It.IsAny<DateTime?>()))
+        mockService.Setup(s => s.GetProjectsAsync(null, null, It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ProjectInfo>());
 
         var controller = new ImageController(new Mock<ILogger<ImageController>>().Object,
@@ -26,7 +27,9 @@ public class GetProjectsTimestampTests
 
         var result = await controller.GetProjects(null, null, "01/02/2025");
         Assert.IsInstanceOf<OkObjectResult>(result);
-        mockService.Verify(s => s.GetProjectsAsync(null, null, It.Is<DateTime?>(d => d!.Value.Year == 2025 && d.Value.Month == 1 && d.Value.Day == 2)), Times.Once);
+        mockService.Verify(s => s.GetProjectsAsync(null, null,
+            It.Is<DateTime?>(d => d!.Value.Year == 2025 && d.Value.Month == 1 && d.Value.Day == 2),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/VectorStoreTests.cs
@@ -3,6 +3,7 @@ using Api.Interfaces;
 using AzurePhotoFlow.Services;
 using Moq;
 using NUnit.Framework;
+using Microsoft.Extensions.Logging;
 using Qdrant.Client.Grpc;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +23,7 @@ public class VectorStoreTests
             .Callback<string, IEnumerable<PointStruct>>((c, pts) => received = pts)
             .Returns(Task.CompletedTask);
 
-        var store = new QdrantVectorStore(mockWrapper.Object);
+        var store = new QdrantVectorStore(new Mock<ILogger<QdrantVectorStore>>().Object, mockWrapper.Object);
         var embeddings = new List<ImageEmbedding>
         {
             new ImageEmbedding("key", new float[] { 1f })


### PR DESCRIPTION
## Summary
- add `ImageUploadResult` to capture upload success and errors
- validate user inputs in controllers via attributes/manual checks
- return detailed results from upload services instead of `false`
- update unit tests and fix compilation issues

## Testing
- `dotnet test tests/backend/backend.tests.sln` *(fails: 8 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684be20d5f5883299e93316e903c06ca