### PR TITLE
Switch ProjectInfo to camelCase fields

### DIFF
--- a/backend/AzurePhotoFlow.Api/Models/ProjectInfo.cs
+++ b/backend/AzurePhotoFlow.Api/Models/ProjectInfo.cs
@@ -5,27 +5,27 @@ namespace Api.Models;
 public class ProjectInfo
 {
     [Required]
-    [JsonPropertyName("ProjectName")]
+    [JsonPropertyName("projectName")]
     public string Name { get; set; }
 
     [Required]
-    [JsonPropertyName("TimeStamp")]
+    [JsonPropertyName("timestamp")]
     public DateTime Datestamp { get; set; }
 
-    [JsonPropertyName("Directories")]
+    [JsonPropertyName("directories")]
     public List<ProjectDirectory> Directories { get; set; } = new List<ProjectDirectory>();
 }
 
 public class ProjectDirectory
 {
     [Required]
-    [JsonPropertyName("DirectoryName")]
+    [JsonPropertyName("directoryName")]
     public string Name { get; set; }
 
-    [JsonPropertyName("RawFilesCount")]
+    [JsonPropertyName("rawFilesCount")]
     public int RawFilesCount { get; set; }
 
-    [JsonPropertyName("ProcessedFilesCount")]
+    [JsonPropertyName("processedFilesCount")]
     public int ProcessedFilesCount { get; set; }
 }
 

--- a/frontend/src/components/ImageSearch.jsx
+++ b/frontend/src/components/ImageSearch.jsx
@@ -3,6 +3,12 @@ import searchService from '../services/searchService';
 import apiClient from '../services/apiClient';
 import '../styles/ImageSearch.css';
 
+export const extractFilterOptions = (projects) => {
+    const uniqueProjects = [...new Set(projects.map(p => p.projectName).filter(Boolean))];
+    const uniqueYears = [...new Set(projects.map(p => new Date(p.timestamp).getFullYear()).filter(Boolean))];
+    return { uniqueProjects, uniqueYears };
+};
+
 const ImageSearchNew = () => {
     console.log('ImageSearchNew component loaded - VERSION WITHOUT SystemStatus');
     const [searchQuery, setSearchQuery] = useState('');
@@ -32,11 +38,9 @@ const ImageSearchNew = () => {
             try {
                 const response = await apiClient.get('/api/image/projects');
                 const projects = response.data || [];
-                
-                // Extract unique project names and years
-                const uniqueProjects = [...new Set(projects.map(p => p.Name).filter(Boolean))];
-                const uniqueYears = [...new Set(projects.map(p => new Date(p.Datestamp).getFullYear()).filter(Boolean))];
-                
+
+                const { uniqueProjects, uniqueYears } = extractFilterOptions(projects);
+
                 setAvailableProjects(uniqueProjects);
                 setAvailableYears(uniqueYears.sort((a, b) => b - a)); // Sort years descending
             } catch (err) {

--- a/tests/frontend/unit/ImageSearchDropdowns.test.jsx
+++ b/tests/frontend/unit/ImageSearchDropdowns.test.jsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { extractFilterOptions } from '@frontend/components/ImageSearch.jsx';
+
+const sampleProjects = [
+  { projectName: 'project1', timestamp: '2023-05-01T00:00:00Z' },
+  { projectName: 'project2', timestamp: '2024-06-15T00:00:00Z' },
+];
+
+describe('ImageSearch filter extraction', () => {
+  it('returns unique project names and years', () => {
+    const { uniqueProjects, uniqueYears } = extractFilterOptions(sampleProjects);
+    expect(uniqueProjects).toEqual(['project1', 'project2']);
+    expect(uniqueYears).toEqual([2023, 2024]);
+  });
+});


### PR DESCRIPTION
## Summary
- update ProjectInfo API model fields to camelCase names
- provide helper to extract project/year filter options
- update ImageSearch component to use camelCase fields
- test filter extraction logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68559c1767808329b7c76ec31bcf9d9d