### PR TITLE
Allow configurable large uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ npm run dev
 ### Infrastructure Setup
 The infrastructure for AzurePhotoFlow is managed using Terraform. Scripts are located in the `infrastructure/` directory. Refer to the `docs/setup.md` for detailed deployment instructions (even if the doc is currently empty).
 
+## Configuration
+The backend limits upload sizes for multipart requests. By default the limit is **100MB**. To allow larger uploads (for example large zip archives), set the environment variable `MAX_UPLOAD_SIZE_MB` to the desired size in megabytes before starting the backend.
+
 ## Usage
 [Placeholder - This section will be updated with detailed instructions on how to use the application's features. Key functionalities include user registration/login, photo uploading, browsing photo galleries, searching for photos using various criteria (tags, text in images, natural language), and viewing recognized faces.]
 

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -103,7 +103,7 @@ builder.Services.AddSingleton<IEmbeddingService, EmbeddingService>();
 
 builder.Services.Configure<FormOptions>(options =>
 {
-    options.MultipartBodyLengthLimit = 104_857_600; // 100MB
+    options.MultipartBodyLengthLimit = UploadConfigHelper.GetMultipartBodyLengthLimit();
 });
 
 // Retrieve and Validate Environment Variables

--- a/backend/AzurePhotoFlow.Api/Services/UploadConfigHelper.cs
+++ b/backend/AzurePhotoFlow.Api/Services/UploadConfigHelper.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Http.Features;
+
+namespace AzurePhotoFlow.Services;
+
+public static class UploadConfigHelper
+{
+    private const long DefaultLimit = 104_857_600; // 100MB
+
+    public static long GetMultipartBodyLengthLimit()
+    {
+        var env = Environment.GetEnvironmentVariable("MAX_UPLOAD_SIZE_MB");
+        if (!string.IsNullOrWhiteSpace(env) && int.TryParse(env, out var mb) && mb > 0)
+        {
+            return mb * 1024L * 1024L;
+        }
+        return DefaultLimit;
+    }
+}

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/UploadConfigHelperTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/UploadConfigHelperTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using AzurePhotoFlow.Services;
+
+namespace unitTests;
+
+[TestFixture]
+public class UploadConfigHelperTests
+{
+    [TearDown]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable("MAX_UPLOAD_SIZE_MB", null);
+    }
+
+    [Test]
+    public void DefaultLimit_WhenEnvVarMissing_Returns100MB()
+    {
+        Environment.SetEnvironmentVariable("MAX_UPLOAD_SIZE_MB", null);
+        long result = UploadConfigHelper.GetMultipartBodyLengthLimit();
+        Assert.AreEqual(104_857_600, result);
+    }
+
+    [Test]
+    public void CustomLimit_FromEnvVar_ReturnsValueInBytes()
+    {
+        Environment.SetEnvironmentVariable("MAX_UPLOAD_SIZE_MB", "512");
+        long result = UploadConfigHelper.GetMultipartBodyLengthLimit();
+        Assert.AreEqual(512 * 1024L * 1024L, result);
+    }
+}


### PR DESCRIPTION
## Summary
- make max upload limit configurable
- document the MAX_UPLOAD_SIZE_MB environment variable
- add helper tests for upload limit

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855af0ea16883299fd3439a9959072f