### PR TITLE
Ensure camelCase JSON responses

### DIFF
--- a/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
+++ b/backend/AzurePhotoFlow.Api/Controllers/ImageController.cs
@@ -61,8 +61,8 @@ public class ImageController : ControllerBase
 
             return Ok(new
             {
-                Message = "Directory uploaded and files extracted successfully.",
-                Files = result
+                message = "Directory uploaded and files extracted successfully.",
+                files = result
             });
         }
         catch (Exception ex)
@@ -112,8 +112,8 @@ public class ImageController : ControllerBase
 
             return Ok(new
             {
-                Message = "Processed directory uploaded and files extracted successfully.",
-                Files = result
+                message = "Processed directory uploaded and files extracted successfully.",
+                files = result
             });
         }
         catch (InvalidOperationException ex)
@@ -121,7 +121,7 @@ public class ImageController : ControllerBase
             // Handle specific exception for missing raw files
             return BadRequest(new
             {
-                Message = ex.Message
+                message = ex.Message
             });
         }
         catch (Exception ex)

--- a/backend/AzurePhotoFlow.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/AzurePhotoFlow.Api/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,13 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddVectorStore(this IServiceCollection services)
     {
         services.AddHttpClient<IQdrantClientWrapper, QdrantClientWrapper>();
+        services.AddSingleton(provider =>
+        {
+            var host = Environment.GetEnvironmentVariable("QDRANT_HOST") ?? "localhost";
+            var portEnv = Environment.GetEnvironmentVariable("QDRANT_PORT") ?? "6333";
+            var port = int.TryParse(portEnv, out var p) ? p : 6333;
+            return new QdrantClient(host, port);
+        });
         services.AddSingleton<IVectorStore, QdrantVectorStore>();
 
         return services;

--- a/backend/AzurePhotoFlow.Api/Models/SearchModels.cs
+++ b/backend/AzurePhotoFlow.Api/Models/SearchModels.cs
@@ -1,0 +1,148 @@
+using System.Text.Json.Serialization;
+
+namespace Api.Models;
+
+public class SemanticSearchRequest
+{
+    public string Query { get; set; } = string.Empty;
+    public int Limit { get; set; } = 20;
+    public double Threshold { get; set; } = 0.5;
+    public string? ProjectName { get; set; }
+    public string? Year { get; set; }
+}
+
+public class SimilaritySearchRequest
+{
+    public string ObjectKey { get; set; } = string.Empty;
+    public int Limit { get; set; } = 20;
+    public double Threshold { get; set; } = 0.5;
+    public string? ProjectName { get; set; }
+    public string? Year { get; set; }
+}
+
+public class ComplexSearchRequest
+{
+    public string? SemanticQuery { get; set; }
+    public string? SimilarityReferenceKey { get; set; }
+    public int Limit { get; set; } = 20;
+    public double Threshold { get; set; } = 0.5;
+    public SearchCombinationMode CombinationMode { get; set; } = SearchCombinationMode.WeightedCombination;
+    public double SemanticWeight { get; set; } = 0.5;
+    public double SimilarityWeight { get; set; } = 0.5;
+    public SearchFilters? Filters { get; set; }
+}
+
+public enum SearchCombinationMode
+{
+    Union,
+    Intersection,
+    WeightedCombination
+}
+
+public class SearchFilters
+{
+    public List<string>? ProjectNames { get; set; }
+    public List<string>? Years { get; set; }
+    public List<string>? DirectoryNames { get; set; }
+    public List<string>? FileExtensions { get; set; }
+    public UploadDateRange? UploadDateRange { get; set; }
+    public Dictionary<string, object>? CustomFilters { get; set; }
+}
+
+public class UploadDateRange
+{
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+}
+
+public class SemanticSearchResponse
+{
+    public string Query { get; set; } = string.Empty;
+    public List<SemanticSearchResult> Results { get; set; } = new();
+    public int TotalResults { get; set; }
+    public long TotalImagesSearched { get; set; }
+    public string? CollectionName { get; set; }
+    public long ProcessingTimeMs { get; set; }
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public class SimilaritySearchResponse
+{
+    public string ReferenceObjectKey { get; set; } = string.Empty;
+    public List<SimilaritySearchResult> Results { get; set; } = new();
+    public int TotalResults { get; set; }
+    public long ProcessingTimeMs { get; set; }
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public class ComplexSearchResponse
+{
+    public ComplexSearchRequest? Request { get; set; }
+    public List<ComplexSearchResult> Results { get; set; } = new();
+    public int TotalResults { get; set; }
+    public long ProcessingTimeMs { get; set; }
+    public SearchResultBreakdown? Breakdown { get; set; }
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public class SemanticSearchResult
+{
+    public string ObjectKey { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public string? ProjectName { get; set; }
+    public string? DirectoryName { get; set; }
+    public string? Year { get; set; }
+    public DateTime? UploadDate { get; set; }
+    public string? ImageUrl { get; set; }
+    public double SimilarityScore { get; set; }
+    public Dictionary<string, object> Metadata { get; set; } = new();
+}
+
+public class SimilaritySearchResult
+{
+    public string ObjectKey { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public string? ProjectName { get; set; }
+    public string? DirectoryName { get; set; }
+    public string? Year { get; set; }
+    public DateTime? UploadDate { get; set; }
+    public string? ImageUrl { get; set; }
+    public double SimilarityScore { get; set; }
+    public Dictionary<string, object> Metadata { get; set; } = new();
+}
+
+public class ComplexSearchResult
+{
+    public string ObjectKey { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public string? ProjectName { get; set; }
+    public string? DirectoryName { get; set; }
+    public string? Year { get; set; }
+    public DateTime? UploadDate { get; set; }
+    public string? ImageUrl { get; set; }
+    public Dictionary<string, object>? Metadata { get; set; }
+    public double? SemanticScore { get; set; }
+    public double? SimilarityScore { get; set; }
+    public double RelevanceScore { get; set; }
+    public List<string> MatchedSearchTypes { get; set; } = new();
+}
+
+public class SearchResultBreakdown
+{
+    public int SemanticResults { get; set; }
+    public int SimilarityResults { get; set; }
+    public int OverlapResults { get; set; }
+    public long SemanticSearchTimeMs { get; set; }
+    public long SimilaritySearchTimeMs { get; set; }
+    public long CombinationTimeMs { get; set; }
+}
+
+public class VectorSearchResult
+{
+    public string ObjectKey { get; set; } = string.Empty;
+    public double SimilarityScore { get; set; }
+    public Dictionary<string, object> Metadata { get; set; } = new();
+}

--- a/backend/AzurePhotoFlow.Api/Program.cs
+++ b/backend/AzurePhotoFlow.Api/Program.cs
@@ -38,7 +38,7 @@ builder.Services.AddCors(options =>
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
     {
-        options.JsonSerializerOptions.PropertyNamingPolicy = null;
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.JsonSerializerOptions.WriteIndented = true;
     })
     .ConfigureApiBehaviorOptions(options =>
@@ -54,9 +54,9 @@ builder.Services.AddControllers()
 
             return new BadRequestObjectResult(new
             {
-                Status = StatusCodes.Status400BadRequest,
-                Message = "Validation errors occurred",
-                Errors = errors
+                status = StatusCodes.Status400BadRequest,
+                message = "Validation errors occurred",
+                errors
             });
         };
     });

--- a/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/SearchControllerSerializationTests.cs
+++ b/tests/backend/AzurePhotoFlow.Api.Tests/UnitTests/SearchControllerSerializationTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Api.Controllers;
+using Api.Interfaces;
+using Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace unitTests;
+
+[TestFixture]
+public class SearchControllerSerializationTests
+{
+    [Test]
+    public async Task SemanticSearch_Response_UsesCamelCaseProperties()
+    {
+        var logger = new Mock<ILogger<SearchController>>();
+        var embedding = new Mock<IEmbeddingService>();
+        embedding.Setup(e => e.GenerateTextEmbeddingAsync(It.IsAny<string>()))
+            .ReturnsAsync(new float[] { 0.1f });
+
+        var store = new Mock<IVectorStore>();
+        store.Setup(s => s.SearchAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<Dictionary<string, object>>()))
+            .ReturnsAsync(new List<VectorSearchResult>
+            {
+                new VectorSearchResult
+                {
+                    ObjectKey = "img.jpg",
+                    SimilarityScore = 0.9,
+                    Metadata = new Dictionary<string, object>{{"path","2024/ts/project/dir/img.jpg"}}
+                }
+            });
+        store.Setup(s => s.GetTotalCountAsync(It.IsAny<Dictionary<string, object>>()))
+            .ReturnsAsync(1);
+        store.Setup(s => s.GetCollectionNameAsync()).ReturnsAsync("images");
+
+        var controller = new SearchController(logger.Object, embedding.Object, store.Object);
+
+        var result = await controller.SemanticSearch("test");
+        var ok = result.Result as OkObjectResult;
+        Assert.NotNull(ok);
+
+        var json = JsonSerializer.Serialize(ok!.Value, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("query", out _));
+        Assert.True(doc.RootElement.TryGetProperty("results", out var results));
+        Assert.True(results[0].TryGetProperty("objectKey", out _));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce camelCase naming for JSON serialization
- update validation error shape to use camelCase
- adjust `ImageController` responses to camelCase
- register QdrantClient in service extension
- simplify vector store UUID handling
- add missing search models
- add unit test verifying camelCase serialization for `SearchController`

## Testing
- `dotnet test tests/backend/backend.tests.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68568200035083299d82d641bac906f0