### PR TITLE
Fix duplicate upload ID mismatch

### DIFF
--- a/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
+++ b/backend/AzurePhotoFlow.Api/Services/MinIOImageUploadService.cs
@@ -166,7 +166,10 @@ public class MinIOImageUploadService : IImageUploadService
                     // Save mapping to database using a new scope to be consistent
                     using var scope = _serviceScopeFactory.CreateScope();
                     var repository = scope.ServiceProvider.GetRequiredService<IImageMappingRepository>();
-                    await repository.AddAsync(imageMapping);
+                    var savedMapping = await repository.AddAsync(imageMapping);
+
+                    // If the repository returned an existing mapping, use its Id
+                    imageMapping = savedMapping;
 
                     // Add to uploaded files list
                     uploadedFiles.Add(new UploadedFileInfo


### PR DESCRIPTION
## Summary
- ensure `ExtractAndUploadImagesAsync` returns the ID from the saved mapping
- mock scoped repository in upload service tests
- test that duplicate uploads return the existing mapping ID

## Testing
- `dotnet test tests/backend/backend.tests.sln --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859456cbd1c8329a08303b7c2b0c494